### PR TITLE
Dispose controllers in ExerciseTile

### DIFF
--- a/lib/src/features/routines/presentation/widgets/exercise_tile.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_tile.dart
@@ -257,6 +257,20 @@ class ExerciseTileState extends State<ExerciseTile>
       );
 
   @override
+  void dispose() {
+    for (final c in _repCtl) {
+      c.dispose();
+    }
+    for (final c in _kgCtl) {
+      c.dispose();
+    }
+    for (final c in _rirCtl) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     super.build(context);
     return GestureDetector(


### PR DESCRIPTION
## Summary
- override `dispose()` in `ExerciseTileState`
- dispose all text controllers before calling `super.dispose()`

## Testing
- `dart format -o none lib/src/features/routines/presentation/widgets/exercise_tile.dart`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_685177dc7da88331b7ccf8ab96a8ff1c