### PR TITLE
Add collection package for firstWhereOrNull

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
 
   # 🧭 Navigation (optional but clean)
   go_router: ^13.0.0
+  collection: ^1.19.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `collection` dependency to use `firstWhereOrNull`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685177de4f8c8331bcdbd19941dff1b5