### PR TITLE
Add editable profile

### DIFF
--- a/lib/src/features/profile/data/repositories/profile_repository_impl.dart
+++ b/lib/src/features/profile/data/repositories/profile_repository_impl.dart
@@ -7,6 +7,30 @@ import '../../domain/entities/body_metric.dart';
 import '../../domain/repositories/profile_repository.dart';
 
 class ProfileRepositoryImpl implements ProfileRepository {
+  Future<File> _getOrCreateFile(String filename) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File('${dir.path}/$filename');
+    if (!await file.exists()) {
+      final schema = kTableSchemas[filename]!;
+      final excel = Excel.createExcel();
+      final defaultSheet = excel.getDefaultSheet();
+      if (defaultSheet != null) {
+        excel.rename(defaultSheet, schema.sheetName);
+      }
+      excel[schema.sheetName]!.appendRow(
+        schema.headers.map<CellValue?>((e) => TextCellValue(e)).toList(),
+      );
+      excel[schema.sheetName]!
+          .appendRow(schema.sample.map<CellValue?>((e) {
+        if (e is int) return IntCellValue(e);
+        if (e is double) return DoubleCellValue(e);
+        return TextCellValue(e.toString());
+      }).toList());
+      final bytes = excel.save();
+      if (bytes != null) await file.writeAsBytes(bytes);
+    }
+    return file;
+  }
   Future<Excel?> _openSheet(String filename) async {
     final dir = await getApplicationDocumentsDirectory();
     final file = File('${dir.path}/$filename');
@@ -78,5 +102,45 @@ class ProfileRepositoryImpl implements ProfileRepository {
         age: _cast<int>(r[14]) ?? 0,
       );
     }).toList();
+  }
+
+  @override
+  Future<void> updateUserProfile(UserProfile p) async {
+    final file = await _getOrCreateFile('user.xlsx');
+    final excel = Excel.decodeBytes(await file.readAsBytes());
+    final sheet = excel[kTableSchemas['user.xlsx']!.sheetName]!;
+    final values = [
+      IntCellValue(p.id),
+      IntCellValue(p.age),
+      TextCellValue(p.gender),
+      DoubleCellValue(p.weight),
+      DoubleCellValue(p.height),
+      TextCellValue(p.experienceLevel),
+      TextCellValue(p.goal),
+      DoubleCellValue(p.targetWeight),
+      DoubleCellValue(p.targetBodyFat),
+      DoubleCellValue(p.targetNeck),
+      DoubleCellValue(p.targetShoulders),
+      DoubleCellValue(p.targetChest),
+      DoubleCellValue(p.targetAbdomen),
+      DoubleCellValue(p.targetWaist),
+      DoubleCellValue(p.targetGlutes),
+      DoubleCellValue(p.targetThigh),
+      DoubleCellValue(p.targetCalf),
+      DoubleCellValue(p.targetArm),
+      DoubleCellValue(p.targetForearm),
+    ];
+
+    if (sheet.rows.length > 1) {
+      for (var i = 0; i < values.length; i++) {
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: i, rowIndex: 1),
+          values[i],
+        );
+      }
+    } else {
+      sheet.appendRow(values);
+    }
+    await file.writeAsBytes(excel.save()!);
   }
 }

--- a/lib/src/features/profile/domain/repositories/profile_repository.dart
+++ b/lib/src/features/profile/domain/repositories/profile_repository.dart
@@ -4,4 +4,5 @@ import '../entities/body_metric.dart';
 abstract class ProfileRepository {
   Future<UserProfile?> getUserProfile();
   Future<List<BodyMetric>> getBodyMetrics();
+  Future<void> updateUserProfile(UserProfile profile);
 }

--- a/lib/src/features/profile/domain/usecases/update_user_profile_usecase.dart
+++ b/lib/src/features/profile/domain/usecases/update_user_profile_usecase.dart
@@ -1,0 +1,10 @@
+import '../repositories/profile_repository.dart';
+import '../entities/user_profile.dart';
+
+class UpdateUserProfileUseCase {
+  final ProfileRepository _repo;
+  const UpdateUserProfileUseCase(this._repo);
+
+  Future<void> call(UserProfile profile) =>
+      _repo.updateUserProfile(profile);
+}

--- a/lib/src/features/profile/presentation/widgets/edit_profile_dialog.dart
+++ b/lib/src/features/profile/presentation/widgets/edit_profile_dialog.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+import '../../domain/entities/user_profile.dart';
+
+class EditProfileDialog extends StatefulWidget {
+  final UserProfile user;
+  const EditProfileDialog({super.key, required this.user});
+
+  @override
+  State<EditProfileDialog> createState() => _EditProfileDialogState();
+}
+
+class _EditProfileDialogState extends State<EditProfileDialog> {
+  late final TextEditingController ageCtl;
+  late final TextEditingController genderCtl;
+  late final TextEditingController weightCtl;
+  late final TextEditingController heightCtl;
+  late final TextEditingController levelCtl;
+  late final TextEditingController goalCtl;
+  late final TextEditingController targetWeightCtl;
+  late final TextEditingController targetBfCtl;
+  late final TextEditingController targetNeckCtl;
+  late final TextEditingController targetShouldersCtl;
+  late final TextEditingController targetChestCtl;
+  late final TextEditingController targetAbdomenCtl;
+  late final TextEditingController targetWaistCtl;
+  late final TextEditingController targetGlutesCtl;
+  late final TextEditingController targetThighCtl;
+  late final TextEditingController targetCalfCtl;
+  late final TextEditingController targetArmCtl;
+  late final TextEditingController targetForearmCtl;
+
+  @override
+  void initState() {
+    super.initState();
+    final u = widget.user;
+    ageCtl = TextEditingController(text: u.age.toString());
+    genderCtl = TextEditingController(text: u.gender);
+    weightCtl = TextEditingController(text: u.weight.toString());
+    heightCtl = TextEditingController(text: u.height.toString());
+    levelCtl = TextEditingController(text: u.experienceLevel);
+    goalCtl = TextEditingController(text: u.goal);
+    targetWeightCtl = TextEditingController(text: u.targetWeight.toString());
+    targetBfCtl = TextEditingController(text: u.targetBodyFat.toString());
+    targetNeckCtl = TextEditingController(text: u.targetNeck.toString());
+    targetShouldersCtl = TextEditingController(text: u.targetShoulders.toString());
+    targetChestCtl = TextEditingController(text: u.targetChest.toString());
+    targetAbdomenCtl = TextEditingController(text: u.targetAbdomen.toString());
+    targetWaistCtl = TextEditingController(text: u.targetWaist.toString());
+    targetGlutesCtl = TextEditingController(text: u.targetGlutes.toString());
+    targetThighCtl = TextEditingController(text: u.targetThigh.toString());
+    targetCalfCtl = TextEditingController(text: u.targetCalf.toString());
+    targetArmCtl = TextEditingController(text: u.targetArm.toString());
+    targetForearmCtl = TextEditingController(text: u.targetForearm.toString());
+  }
+
+  @override
+  void dispose() {
+    ageCtl.dispose();
+    genderCtl.dispose();
+    weightCtl.dispose();
+    heightCtl.dispose();
+    levelCtl.dispose();
+    goalCtl.dispose();
+    targetWeightCtl.dispose();
+    targetBfCtl.dispose();
+    targetNeckCtl.dispose();
+    targetShouldersCtl.dispose();
+    targetChestCtl.dispose();
+    targetAbdomenCtl.dispose();
+    targetWaistCtl.dispose();
+    targetGlutesCtl.dispose();
+    targetThighCtl.dispose();
+    targetCalfCtl.dispose();
+    targetArmCtl.dispose();
+    targetForearmCtl.dispose();
+    super.dispose();
+  }
+
+  TextField _field(String label, TextEditingController ctl, {TextInputType? type}) {
+    return TextField(
+      controller: ctl,
+      keyboardType: type,
+      decoration: InputDecoration(labelText: label),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Editar perfil'),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _field('Edad', ageCtl, type: TextInputType.number),
+            _field('Género', genderCtl),
+            _field('Peso', weightCtl, type: TextInputType.number),
+            _field('Altura', heightCtl, type: TextInputType.number),
+            _field('Nivel', levelCtl),
+            _field('Meta', goalCtl),
+            const Divider(),
+            _field('Peso deseado', targetWeightCtl, type: TextInputType.number),
+            _field('BF deseado', targetBfCtl, type: TextInputType.number),
+            _field('Cuello deseado', targetNeckCtl, type: TextInputType.number),
+            _field('Hombros deseados', targetShouldersCtl, type: TextInputType.number),
+            _field('Pecho deseado', targetChestCtl, type: TextInputType.number),
+            _field('Abdomen deseado', targetAbdomenCtl, type: TextInputType.number),
+            _field('Cintura deseada', targetWaistCtl, type: TextInputType.number),
+            _field('Glúteos deseados', targetGlutesCtl, type: TextInputType.number),
+            _field('Muslo deseado', targetThighCtl, type: TextInputType.number),
+            _field('Pantorrilla deseada', targetCalfCtl, type: TextInputType.number),
+            _field('Brazo deseado', targetArmCtl, type: TextInputType.number),
+            _field('Antebrazo deseado', targetForearmCtl, type: TextInputType.number),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancelar'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            final p = UserProfile(
+              id: widget.user.id,
+              age: int.tryParse(ageCtl.text) ?? widget.user.age,
+              gender: genderCtl.text,
+              weight: double.tryParse(weightCtl.text) ?? widget.user.weight,
+              height: double.tryParse(heightCtl.text) ?? widget.user.height,
+              experienceLevel: levelCtl.text,
+              goal: goalCtl.text,
+              targetWeight: double.tryParse(targetWeightCtl.text) ?? widget.user.targetWeight,
+              targetBodyFat: double.tryParse(targetBfCtl.text) ?? widget.user.targetBodyFat,
+              targetNeck: double.tryParse(targetNeckCtl.text) ?? widget.user.targetNeck,
+              targetShoulders: double.tryParse(targetShouldersCtl.text) ?? widget.user.targetShoulders,
+              targetChest: double.tryParse(targetChestCtl.text) ?? widget.user.targetChest,
+              targetAbdomen: double.tryParse(targetAbdomenCtl.text) ?? widget.user.targetAbdomen,
+              targetWaist: double.tryParse(targetWaistCtl.text) ?? widget.user.targetWaist,
+              targetGlutes: double.tryParse(targetGlutesCtl.text) ?? widget.user.targetGlutes,
+              targetThigh: double.tryParse(targetThighCtl.text) ?? widget.user.targetThigh,
+              targetCalf: double.tryParse(targetCalfCtl.text) ?? widget.user.targetCalf,
+              targetArm: double.tryParse(targetArmCtl.text) ?? widget.user.targetArm,
+              targetForearm: double.tryParse(targetForearmCtl.text) ?? widget.user.targetForearm,
+            );
+            Navigator.pop(context, p);
+          },
+          child: const Text('Guardar'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- enable profile edits with dialog
- update profile repository to save changes
- allow UI to edit and persist profile data

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685448657a348331b32f81f229f32919