### PR TITLE
Improve exercise selection and caching

### DIFF
--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -11,6 +11,7 @@ import '../../domain/repositories/workout_plan_repository.dart';
 import '../../../../data/schema/schemas.dart';
 
 class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
+  List<Exercise>? _exerciseCache;
   Future<File> _getOrCreateFile(String filename) async {
     final dir = await getApplicationDocumentsDirectory();
     final file = File('${dir.path}/$filename');
@@ -120,20 +121,27 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
 
   @override
   Future<List<Exercise>> getAllExercises() async {
+    if (_exerciseCache != null) return _exerciseCache!;
+
     final exFile = await _getOrCreateFile('exercise.xlsx');
-    final exSheet = Excel.decodeBytes(await exFile.readAsBytes())[kTableSchemas['exercise.xlsx']!.sheetName];
+    final exSheet =
+        Excel.decodeBytes(await exFile.readAsBytes())[kTableSchemas['exercise.xlsx']!.sheetName];
     if (exSheet == null) return [];
-    return exSheet.rows
+
+    _exerciseCache = exSheet.rows
         .skip(1)
         .where((row) => row.isNotEmpty)
-        .map((row) => Exercise(
-              id: _cast<int>(row[0]) ?? 0,
-              name: _cast<String>(row[1]) ?? '',
-              description: _cast<String>(row[2]) ?? '',
-              category: _cast<String>(row[3]) ?? '',
-              mainMuscleGroup: _cast<String>(row[4]) ?? '',
-            ))
+        .map(
+          (row) => Exercise(
+            id: _cast<int>(row[0]) ?? 0,
+            name: _cast<String>(row[1]) ?? '',
+            description: _cast<String>(row[2]) ?? '',
+            category: _cast<String>(row[3]) ?? '',
+            mainMuscleGroup: _cast<String>(row[4]) ?? '',
+          ),
+        )
         .toList();
+    return _exerciseCache!;
   }
 
   @override

--- a/lib/src/features/routines/presentation/pages/select_exercise_screen.dart
+++ b/lib/src/features/routines/presentation/pages/select_exercise_screen.dart
@@ -28,7 +28,11 @@ class _SelectExerciseScreenState extends ConsumerState<SelectExerciseScreen> {
       appBar: AppBar(title: const Text('Elegir ejercicio')),
       body: asyncExercises.when(
         data: (ex) {
-          final exercises = ex.where((e) => widget.groups.contains(e.mainMuscleGroup)).toList();
+          final exercises = _group == 'Todos'
+              ? ex.toList()
+              : ex
+                  .where((e) => widget.groups.contains(e.mainMuscleGroup))
+                  .toList();
           final filtered = exercises.where((e) {
             final byGroup = _group == 'Todos' || e.mainMuscleGroup == _group;
             final byName = e.name.toLowerCase().contains(_query.toLowerCase());

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -46,6 +46,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     '1','2','3','4','5','6','7','8','9','10'
   ];
   static const List<String> _scale5 = ['1','2','3','4','5'];
+  static const int _defaultSets = 3;
 
   @override
   void initState() {
@@ -273,16 +274,12 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     );
     if (picked != null) {
       final notifier = ref.read(workoutLogProvider.notifier);
-      for (var i = 1; i <= detail.sets; i++) {
-        notifier.remove(WorkoutLogEntry(
-          date: DateTime.now(),
-          planId: widget.planId,
-          exerciseId: detail.exerciseId,
-          setNumber: i,
-          reps: 0,
-          weight: 0,
-          rir: 0,
-        ));
+      final existingEntries = notifier.state.values.where((entry) =>
+          entry.planId == widget.planId &&
+          entry.exerciseId == detail.exerciseId &&
+          entry.setNumber <= detail.sets);
+      for (var entry in existingEntries) {
+        notifier.remove(entry);
       }
       setState(() {
         _keys.remove(detail.exerciseId);
@@ -319,7 +316,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
           exerciseId: exercise.id,
           name: exercise.name,
           description: exercise.description,
-          sets: 3,
+          sets: _defaultSets,
           reps: 10,
           weight: 0,
           restSeconds: 90,


### PR DESCRIPTION
## Summary
- cache exercises in WorkoutPlanRepositoryImpl
- improve filtering in select exercise screen
- remove workout log entries by existing identifiers
- use a constant for default set count

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544a9402cc8331b592a9297ad01308