### PR TITLE
Refactor providers and fix async operations

### DIFF
--- a/lib/src/features/profile/data/repositories/profile_repository_impl.dart
+++ b/lib/src/features/profile/data/repositories/profile_repository_impl.dart
@@ -135,7 +135,12 @@ class ProfileRepositoryImpl implements ProfileRepository {
       DoubleCellValue(m.forearm),
       IntCellValue(m.age),
     ]);
-    await file.writeAsBytes(excel.save()!);
+    final bytes = excel.save();
+    if (bytes != null) {
+      await file.writeAsBytes(bytes);
+    } else {
+      throw Exception('Failed to save Excel file: save() returned null.');
+    }
   }
 
   @override
@@ -175,6 +180,11 @@ class ProfileRepositoryImpl implements ProfileRepository {
     } else {
       sheet.appendRow(values);
     }
-    await file.writeAsBytes(excel.save()!);
+    final bytes = excel.save();
+    if (bytes != null) {
+      await file.writeAsBytes(bytes);
+    } else {
+      throw Exception('Failed to save Excel file: save() returned null.');
+    }
   }
 }

--- a/lib/src/features/profile/presentation/pages/profile_screen.dart
+++ b/lib/src/features/profile/presentation/pages/profile_screen.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../providers/profile_providers.dart';
 import 'metrics_chart_screen.dart';
 import '../widgets/edit_profile_dialog.dart';
 import '../widgets/add_body_metric_dialog.dart';
-import '../../data/repositories/profile_repository_impl.dart';
+import '../providers/profile_providers.dart';
 import '../../domain/usecases/update_user_profile_usecase.dart';
 import '../../domain/usecases/add_body_metric_usecase.dart';
 import '../../domain/entities/user_profile.dart';
@@ -42,7 +41,7 @@ class ProfileScreen extends ConsumerWidget {
                               builder: (_) => EditProfileDialog(user: user),
                             );
                             if (updated != null) {
-                              final repo = ProfileRepositoryImpl();
+                              final repo = ref.read(profileRepositoryProvider);
                               await UpdateUserProfileUseCase(repo)(updated);
                               ref.invalidate(userProfileProvider);
                             }
@@ -61,7 +60,7 @@ class ProfileScreen extends ConsumerWidget {
                               ),
                             );
                             if (metric != null) {
-                              final repo = ProfileRepositoryImpl();
+                              final repo = ref.read(profileRepositoryProvider);
                               await AddBodyMetricUseCase(repo)(metric);
                               ref.invalidate(bodyMetricsProvider);
                             }

--- a/lib/src/features/profile/presentation/providers/profile_providers.dart
+++ b/lib/src/features/profile/presentation/providers/profile_providers.dart
@@ -3,14 +3,15 @@ import '../../data/repositories/profile_repository_impl.dart';
 import '../../domain/usecases/get_user_profile_usecase.dart';
 import '../../domain/usecases/get_body_metrics_usecase.dart';
 
-final _repoProvider = Provider((_) => ProfileRepositoryImpl());
+/// Provides the implementation of [ProfileRepository].
+final profileRepositoryProvider = Provider((_) => ProfileRepositoryImpl());
 
 final userProfileProvider = FutureProvider((ref) {
-  final usecase = GetUserProfileUseCase(ref.watch(_repoProvider));
+  final usecase = GetUserProfileUseCase(ref.watch(profileRepositoryProvider));
   return usecase();
 });
 
 final bodyMetricsProvider = FutureProvider((ref) {
-  final usecase = GetBodyMetricsUseCase(ref.watch(_repoProvider));
+  final usecase = GetBodyMetricsUseCase(ref.watch(profileRepositoryProvider));
   return usecase();
 });

--- a/lib/src/features/routines/presentation/pages/select_exercise_screen.dart
+++ b/lib/src/features/routines/presentation/pages/select_exercise_screen.dart
@@ -11,30 +11,31 @@ class SelectExerciseScreen extends ConsumerStatefulWidget {
 }
 
 class _SelectExerciseScreenState extends ConsumerState<SelectExerciseScreen> {
+  static const allGroupsLabel = 'Todos';
   late String _group;
   String _query = '';
 
   @override
   void initState() {
     super.initState();
-    _group = 'Todos';
+    _group = allGroupsLabel;
   }
 
   @override
   Widget build(BuildContext context) {
     final asyncExercises = ref.watch(allExercisesProvider);
-    final groupsList = ['Todos', ...widget.groups.toList()];
+    final groupsList = [allGroupsLabel, ...widget.groups.toList()];
     return Scaffold(
       appBar: AppBar(title: const Text('Elegir ejercicio')),
       body: asyncExercises.when(
         data: (ex) {
-          final exercises = _group == 'Todos'
+          final exercises = _group == allGroupsLabel
               ? ex.toList()
               : ex
                   .where((e) => widget.groups.contains(e.mainMuscleGroup))
                   .toList();
           final filtered = exercises.where((e) {
-            final byGroup = _group == 'Todos' || e.mainMuscleGroup == _group;
+            final byGroup = _group == allGroupsLabel || e.mainMuscleGroup == _group;
             final byName = e.name.toLowerCase().contains(_query.toLowerCase());
             return byGroup && byName;
           }).toList();

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -274,10 +274,12 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     );
     if (picked != null) {
       final notifier = ref.read(workoutLogProvider.notifier);
-      final existingEntries = notifier.state.values.where((entry) =>
-          entry.planId == widget.planId &&
-          entry.exerciseId == detail.exerciseId &&
-          entry.setNumber <= detail.sets);
+      final existingEntries = notifier.state.values
+          .where((entry) =>
+              entry.planId == widget.planId &&
+              entry.exerciseId == detail.exerciseId &&
+              entry.setNumber <= detail.sets)
+          .toList();
       for (var entry in existingEntries) {
         notifier.remove(entry);
       }

--- a/lib/src/features/routines/presentation/widgets/exercise_tile.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_tile.dart
@@ -129,10 +129,10 @@ class ExerciseTileState extends State<ExerciseTile>
       List.generate(_visibleSets, (i) => i + 1)
           .every((s) => logs['${widget.detail.exerciseId}-$s']?.completed ?? false);
 
-  void _startRestTimer() {
+  Future<void> _startRestTimer() async {
     _restTimer?.cancel();
-    NotificationService.cancelRest();
-    NotificationService.scheduleRestDone(widget.detail.restSeconds);
+    await NotificationService.cancelRest();
+    await NotificationService.scheduleRestDone(widget.detail.restSeconds);
     setState(() => _restRemaining = widget.detail.restSeconds);
     _restTimer = Timer.periodic(const Duration(seconds: 1), (t) {
       if (_restRemaining <= 1) {


### PR DESCRIPTION
## Summary
- expose `profileRepositoryProvider`
- use repository provider in `ProfileScreen`
- handle nullable bytes in `ProfileRepositoryImpl`
- avoid concurrent modification in `StartRoutineScreen`
- remove magic string in `SelectExerciseScreen`
- await rest notification operations

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549f52f25c8331b3179badd2440305