### PR TITLE
Add ExerciseCardV2 widget scaffolding

### DIFF
--- a/lib/src/features/routines/domain/entities/set_entry.dart
+++ b/lib/src/features/routines/domain/entities/set_entry.dart
@@ -1,0 +1,23 @@
+class SetEntry {
+  final int reps;
+  final double weight;
+  final int rir;
+  final bool completed;
+
+  SetEntry({
+    required this.reps,
+    required this.weight,
+    required this.rir,
+    this.completed = true,
+  });
+
+  double get volume => reps * weight;
+
+  SetEntry copyWith({int? reps, double? weight, int? rir, bool? completed}) =>
+      SetEntry(
+        reps: reps ?? this.reps,
+        weight: weight ?? this.weight,
+        rir: rir ?? this.rir,
+        completed: completed ?? this.completed,
+      );
+}

--- a/lib/src/features/routines/presentation/widgets/badge_delta.dart
+++ b/lib/src/features/routines/presentation/widgets/badge_delta.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class BadgeDelta extends StatelessWidget {
+  final int delta;
+  const BadgeDelta(this.delta, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final positive = delta >= 0;
+    final bg = positive ? Colors.green : Colors.red;
+    final icon = positive ? '↑' : '↓';
+    final semantics = 'Progreso ${delta > 0 ? '+' : ''}$delta por ciento';
+    return Semantics(
+      label: semantics,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          '$icon ${delta.abs()}%',
+          style: TextStyle(color: colorScheme.onPrimary, fontSize: 12),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/routines/presentation/widgets/exercise_card_header.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_card_header.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class ExerciseCardHeader extends StatelessWidget {
+  final String name;
+  final bool showBest;
+  final VoidCallback onToggleBest;
+  final VoidCallback onExpand;
+
+  const ExerciseCardHeader({
+    super.key,
+    required this.name,
+    required this.showBest,
+    required this.onToggleBest,
+    required this.onExpand,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(child: Text(name, style: const TextStyle(fontWeight: FontWeight.w600))),
+        IconButton(
+          icon: Icon(showBest ? Icons.star : Icons.star_border),
+          onPressed: onToggleBest,
+        ),
+        IconButton(
+          icon: const Icon(Icons.expand_more),
+          onPressed: onExpand,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/features/routines/presentation/widgets/exercise_card_v2.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_card_v2.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../domain/entities/exercise.dart';
+import '../../domain/entities/set_entry.dart';
+import '../../../history/presentation/providers/history_providers.dart';
+import '../../../routines/domain/entities/workout_log_entry.dart';
+import '../widgets/badge_delta.dart';
+import '../widgets/exercise_card_header.dart';
+import '../widgets/mini_sparkline.dart';
+import '../widgets/sets_table.dart';
+import '../../../../utils/tonnage.dart';
+
+class ExerciseCardV2 extends ConsumerStatefulWidget {
+  final Exercise exercise;
+  final List<SetEntry> planSets;
+  final List<SetEntry> lastSets;
+  final List<SetEntry> bestSets;
+  final List<SetEntry> todaySets;
+  const ExerciseCardV2({
+    super.key,
+    required this.exercise,
+    required this.planSets,
+    required this.lastSets,
+    required this.bestSets,
+    required this.todaySets,
+  });
+
+  @override
+  ConsumerState<ExerciseCardV2> createState() => _ExerciseCardV2State();
+}
+
+class _ExerciseCardV2State extends ConsumerState<ExerciseCardV2>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabs;
+  bool showBest = true, expanded = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabs = TabController(length: 4, vsync: this);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final delta = deltaPercent(
+      tonnage(widget.todaySets),
+      tonnage(widget.lastSets),
+    );
+
+    final history = ref.watch(logsByExerciseProvider(widget.exercise.id));
+    final sparkData = history.when(
+      data: (logs) {
+        final volumes = <double>[];
+        final sorted = List<WorkoutLogEntry>.from(logs);
+        sorted.sort((a, b) => a.date.compareTo(b.date));
+        for (final l in sorted) {
+          volumes.add(l.reps * l.weight);
+        }
+        if (volumes.length > 10) {
+          volumes.removeRange(0, volumes.length - 10);
+        }
+        return volumes;
+      },
+      loading: () => <double>[],
+      error: (_, __) => <double>[],
+    );
+
+    return Card(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          children: [
+            ExerciseCardHeader(
+              name: widget.exercise.name,
+              showBest: showBest,
+              onToggleBest: () => setState(() => showBest = !showBest),
+              onExpand: () => setState(() => expanded = !expanded),
+            ),
+            if (expanded) ...[
+              TabBar(
+                controller: _tabs,
+                tabs: [
+                  const Tab(text: 'Plan'),
+                  const Tab(text: 'Último'),
+                  if (showBest) const Tab(text: 'Mejor'),
+                  const Tab(text: 'Hoy'),
+                ],
+              ),
+              const SizedBox(height: 2),
+              BadgeDelta(delta),
+              SizedBox(
+                height: 200,
+                child: TabBarView(
+                  controller: _tabs,
+                  children: [
+                    SetsTable(widget.planSets),
+                    SetsTable(widget.lastSets),
+                    if (showBest) SetsTable(widget.bestSets),
+                    SetsTable(widget.todaySets, editable: true),
+                  ],
+                ),
+              ),
+              MiniSparkline(data: sparkData),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/routines/presentation/widgets/mini_sparkline.dart
+++ b/lib/src/features/routines/presentation/widgets/mini_sparkline.dart
@@ -1,0 +1,33 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class MiniSparkline extends StatelessWidget {
+  final List<double> data;
+  const MiniSparkline({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    if (data.isEmpty) return const SizedBox(height: 40);
+    final spots = List.generate(
+        data.length, (i) => FlSpot(i.toDouble(), data[i]));
+    return SizedBox(
+      height: 40,
+      child: LineChart(
+        LineChartData(
+          gridData: FlGridData(show: false),
+          titlesData: const FlTitlesData(show: false),
+          borderData: FlBorderData(show: false),
+          lineBarsData: [
+            LineChartBarData(
+              spots: spots,
+              isCurved: false,
+              color: Theme.of(context).colorScheme.primary,
+              barWidth: 2,
+              dotData: FlDotData(show: false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/routines/presentation/widgets/sets_table.dart
+++ b/lib/src/features/routines/presentation/widgets/sets_table.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import '../../domain/entities/set_entry.dart';
+
+class SetsTable extends StatefulWidget {
+  final List<SetEntry> sets;
+  final bool editable;
+  const SetsTable(this.sets, {this.editable = false, super.key});
+
+  @override
+  State<SetsTable> createState() => _SetsTableState();
+}
+
+class _SetsTableState extends State<SetsTable> {
+  late List<SetEntry> _data;
+
+  @override
+  void initState() {
+    super.initState();
+    _data = List.from(widget.sets);
+  }
+
+  void _duplicateLast() {
+    if (_data.isEmpty) return;
+    setState(() {
+      _data.add(_data.last);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rows = List.generate(_data.length, (i) {
+      final set = _data[i];
+      return Row(
+        children: [
+          Expanded(child: Text('${set.reps}')), // reps
+          Expanded(child: Text('${set.weight}kg')),
+          Expanded(child: Text('${set.rir}')),
+          Checkbox(
+            value: set.completed,
+            onChanged: widget.editable
+                ? (v) => setState(() {
+                      _data[i] = set.copyWith(completed: v ?? false);
+                    })
+                : null,
+          ),
+        ],
+      );
+    });
+
+    return Column(
+      children: [
+        ...rows,
+        if (widget.editable)
+          Align(
+            alignment: Alignment.centerRight,
+            child: IconButton(
+              icon: const Icon(Icons.add),
+              onPressed: _duplicateLast,
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/src/utils/tonnage.dart
+++ b/lib/src/utils/tonnage.dart
@@ -1,0 +1,12 @@
+import '../features/routines/domain/entities/set_entry.dart';
+
+/// Returns the sum of reps * weight of each set.
+double tonnage(List<SetEntry> sets) =>
+    sets.fold(0, (sum, e) => sum + e.reps * e.weight);
+
+/// Returns the percent difference between [today] and [last].
+/// Example: 25 -> 30 gives +20%.
+int deltaPercent(double today, double last) {
+  if (last == 0) return today == 0 ? 0 : 100;
+  return (((today - last) / last) * 100).round();
+}

--- a/test/tonnage_test.dart
+++ b/test/tonnage_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fit_log/src/utils/tonnage.dart';
+import 'package:fit_log/src/features/routines/domain/entities/set_entry.dart';
+
+void main() {
+  test('delta percent from 25 to 30 is +20%', () {
+    final today = [SetEntry(reps: 1, weight: 30, rir: 0)];
+    final last = [SetEntry(reps: 1, weight: 25, rir: 0)];
+    final result = deltaPercent(tonnage(today), tonnage(last));
+    expect(result, 20);
+  });
+}


### PR DESCRIPTION
## Summary
- add SetEntry entity
- add tonnage utility and deltaPercent function
- implement ExerciseCardV2 with header, tabs, delta badge and sparkline
- create reusable SetsTable widget and supporting badge/sparkline widgets
- add unit test for deltaPercent

## Testing
- `flutter test test/tonnage_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b835943083319ece26b1f538f0be