### PR TITLE
Add routine editing

### DIFF
--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -261,10 +261,11 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
 
     if (existingRow != -1) {
       if (position != null) {
-        final rowData = sheet.rows[existingRow];
+        final oldRowData = sheet.rows[existingRow];
         sheet.removeRow(existingRow);
         final insertIndex = _findInsertIndex(sheet, planId, position);
-        sheet.insertRowIterables(rowData, insertIndex);
+        final cellValues = oldRowData.map<CellValue?>((cell) => cell?.value).toList();
+        sheet.insertRowIterables(cellValues, insertIndex);
       }
     } else {
       final insertIndex = position == null

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -205,6 +205,33 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
     final excel = Excel.decodeBytes(await file.readAsBytes());
     final sheet = excel[kTableSchemas['plan_exercise.xlsx']!.sheetName]!;
 
+    // If the exercise already exists for this plan just update it
+    for (var i = 1; i < sheet.rows.length; i++) {
+      final row = sheet.rows[i];
+      if (row.isNotEmpty &&
+          _cast<int>(row[0]) == planId &&
+          _cast<int>(row[1]) == detail.exerciseId) {
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 2, rowIndex: i),
+          IntCellValue(detail.sets),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 3, rowIndex: i),
+          IntCellValue(detail.reps),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 4, rowIndex: i),
+          DoubleCellValue(detail.weight),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 5, rowIndex: i),
+          IntCellValue(detail.restSeconds),
+        );
+        await file.writeAsBytes(excel.save()!);
+        return;
+      }
+    }
+
     final row = [
       IntCellValue(planId),
       IntCellValue(detail.exerciseId),
@@ -264,6 +291,7 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
           CellIndex.indexByColumnRow(columnIndex: 5, rowIndex: i),
           IntCellValue(detail.restSeconds),
         );
+        break;
       }
     }
 
@@ -276,11 +304,13 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
     final excel = Excel.decodeBytes(await file.readAsBytes());
     final sheet = excel[kTableSchemas['plan_exercise.xlsx']!.sheetName]!;
 
-    final rows = sheet.rows;
-    for (var i = rows.length - 1; i >= 1; i--) {
-      final r = rows[i];
-      if (r.isNotEmpty && _cast<int>(r[0]) == planId && _cast<int>(r[1]) == exerciseId) {
+    for (var i = sheet.rows.length - 1; i >= 1; i--) {
+      final r = sheet.rows[i];
+      if (r.isNotEmpty &&
+          _cast<int>(r[0]) == planId &&
+          _cast<int>(r[1]) == exerciseId) {
         sheet.removeRow(i);
+        break;
       }
     }
 

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -195,6 +195,60 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
         .toList();
   }
 
+  @override
+  Future<void> addExerciseToPlan(int planId, PlanExerciseDetail detail) async {
+    final file = await _getOrCreateFile('plan_exercise.xlsx');
+    final excel = Excel.decodeBytes(await file.readAsBytes());
+    final sheet = excel[kTableSchemas['plan_exercise.xlsx']!.sheetName]!;
+
+    sheet.appendRow([
+      IntCellValue(planId),
+      IntCellValue(detail.exerciseId),
+      IntCellValue(detail.sets),
+      IntCellValue(detail.reps),
+      DoubleCellValue(detail.weight),
+      IntCellValue(detail.restSeconds),
+      TextCellValue(''),
+    ]);
+
+    await file.writeAsBytes(excel.save()!);
+  }
+
+  @override
+  Future<void> updateExerciseInPlan(int planId, PlanExerciseDetail detail) async {
+    final file = await _getOrCreateFile('plan_exercise.xlsx');
+    final excel = Excel.decodeBytes(await file.readAsBytes());
+    final sheet = excel[kTableSchemas['plan_exercise.xlsx']!.sheetName]!;
+
+    for (var row in sheet.rows.skip(1)) {
+      if (row.isNotEmpty && _cast<int>(row[0]) == planId && _cast<int>(row[1]) == detail.exerciseId) {
+        row[2] = IntCellValue(detail.sets);
+        row[3] = IntCellValue(detail.reps);
+        row[4] = DoubleCellValue(detail.weight);
+        row[5] = IntCellValue(detail.restSeconds);
+      }
+    }
+
+    await file.writeAsBytes(excel.save()!);
+  }
+
+  @override
+  Future<void> deleteExerciseFromPlan(int planId, int exerciseId) async {
+    final file = await _getOrCreateFile('plan_exercise.xlsx');
+    final excel = Excel.decodeBytes(await file.readAsBytes());
+    final sheet = excel[kTableSchemas['plan_exercise.xlsx']!.sheetName]!;
+
+    final rows = sheet.rows;
+    for (var i = rows.length - 1; i >= 1; i--) {
+      final r = rows[i];
+      if (r.isNotEmpty && _cast<int>(r[0]) == planId && _cast<int>(r[1]) == exerciseId) {
+        sheet.removeRow(i);
+      }
+    }
+
+    await file.writeAsBytes(excel.save()!);
+  }
+
 
   @override
   Future<void> saveWorkoutLogs(List<WorkoutLogEntry> logs) async {

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -222,10 +222,10 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
 
     for (var row in sheet.rows.skip(1)) {
       if (row.isNotEmpty && _cast<int>(row[0]) == planId && _cast<int>(row[1]) == detail.exerciseId) {
-        row[2] = IntCellValue(detail.sets);
-        row[3] = IntCellValue(detail.reps);
-        row[4] = DoubleCellValue(detail.weight);
-        row[5] = IntCellValue(detail.restSeconds);
+        row[2]?.value = IntCellValue(detail.sets);
+        row[3]?.value = IntCellValue(detail.reps);
+        row[4]?.value = DoubleCellValue(detail.weight);
+        row[5]?.value = IntCellValue(detail.restSeconds);
       }
     }
 

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -243,12 +243,27 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
     final excel = Excel.decodeBytes(await file.readAsBytes());
     final sheet = excel[kTableSchemas['plan_exercise.xlsx']!.sheetName]!;
 
-    for (var row in sheet.rows.skip(1)) {
-      if (row.isNotEmpty && _cast<int>(row[0]) == planId && _cast<int>(row[1]) == detail.exerciseId) {
-        row[2]?.value = IntCellValue(detail.sets);
-        row[3]?.value = IntCellValue(detail.reps);
-        row[4]?.value = DoubleCellValue(detail.weight);
-        row[5]?.value = IntCellValue(detail.restSeconds);
+    for (var i = 1; i < sheet.rows.length; i++) {
+      final row = sheet.rows[i];
+      if (row.isNotEmpty &&
+          _cast<int>(row[0]) == planId &&
+          _cast<int>(row[1]) == detail.exerciseId) {
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 2, rowIndex: i),
+          IntCellValue(detail.sets),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 3, rowIndex: i),
+          IntCellValue(detail.reps),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 4, rowIndex: i),
+          DoubleCellValue(detail.weight),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 5, rowIndex: i),
+          IntCellValue(detail.restSeconds),
+        );
       }
     }
 

--- a/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
+++ b/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
@@ -15,8 +15,9 @@ abstract class WorkoutPlanRepository {
 
   Future<void> addExerciseToPlan(
     int planId,
-    PlanExerciseDetail detail,
-  );
+    PlanExerciseDetail detail, {
+    int? position,
+  });
 
   Future<void> updateExerciseInPlan(
     int planId,

--- a/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
+++ b/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
@@ -13,6 +13,18 @@ abstract class WorkoutPlanRepository {
   Future<void> createWorkoutPlan(String name, String frequency);
   Future<List<PlanExerciseDetail>> getPlanExerciseDetails(int planId);
 
+  Future<void> addExerciseToPlan(
+    int planId,
+    PlanExerciseDetail detail,
+  );
+
+  Future<void> updateExerciseInPlan(
+    int planId,
+    PlanExerciseDetail detail,
+  );
+
+  Future<void> deleteExerciseFromPlan(int planId, int exerciseId);
+
   //Start session 
   Future<void> saveWorkoutLogs(List<WorkoutLogEntry> logs);
   Future<void> saveWorkoutSession(WorkoutSession session);

--- a/lib/src/features/routines/domain/usecases/add_exercise_to_plan_usecase.dart
+++ b/lib/src/features/routines/domain/usecases/add_exercise_to_plan_usecase.dart
@@ -5,7 +5,11 @@ class AddExerciseToPlanUseCase {
   final WorkoutPlanRepository _repo;
   const AddExerciseToPlanUseCase(this._repo);
 
-  Future<void> call(int planId, PlanExerciseDetail detail) {
-    return _repo.addExerciseToPlan(planId, detail);
+  Future<void> call(
+    int planId,
+    PlanExerciseDetail detail, {
+    int? position,
+  }) {
+    return _repo.addExerciseToPlan(planId, detail, position: position);
   }
 }

--- a/lib/src/features/routines/domain/usecases/add_exercise_to_plan_usecase.dart
+++ b/lib/src/features/routines/domain/usecases/add_exercise_to_plan_usecase.dart
@@ -1,0 +1,11 @@
+import '../repositories/workout_plan_repository.dart';
+import '../entities/plan_exercise_detail.dart';
+
+class AddExerciseToPlanUseCase {
+  final WorkoutPlanRepository _repo;
+  const AddExerciseToPlanUseCase(this._repo);
+
+  Future<void> call(int planId, PlanExerciseDetail detail) {
+    return _repo.addExerciseToPlan(planId, detail);
+  }
+}

--- a/lib/src/features/routines/domain/usecases/delete_exercise_from_plan_usecase.dart
+++ b/lib/src/features/routines/domain/usecases/delete_exercise_from_plan_usecase.dart
@@ -1,0 +1,10 @@
+import '../repositories/workout_plan_repository.dart';
+
+class DeleteExerciseFromPlanUseCase {
+  final WorkoutPlanRepository _repo;
+  const DeleteExerciseFromPlanUseCase(this._repo);
+
+  Future<void> call(int planId, int exerciseId) {
+    return _repo.deleteExerciseFromPlan(planId, exerciseId);
+  }
+}

--- a/lib/src/features/routines/domain/usecases/update_exercise_in_plan_usecase.dart
+++ b/lib/src/features/routines/domain/usecases/update_exercise_in_plan_usecase.dart
@@ -1,0 +1,11 @@
+import '../repositories/workout_plan_repository.dart';
+import '../entities/plan_exercise_detail.dart';
+
+class UpdateExerciseInPlanUseCase {
+  final WorkoutPlanRepository _repo;
+  const UpdateExerciseInPlanUseCase(this._repo);
+
+  Future<void> call(int planId, PlanExerciseDetail detail) {
+    return _repo.updateExerciseInPlan(planId, detail);
+  }
+}

--- a/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
@@ -44,6 +44,36 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
       ),
     );
     if (exercise != null) {
+      final current = await ref.read(
+        planExerciseDetailsProvider(widget.planId).future,
+      );
+      final posCtl = TextEditingController(
+        text: '${current.length + 1}',
+      );
+      final index = await showDialog<int>(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('Posición del ejercicio'),
+          content: TextField(
+            controller: posCtl,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(labelText: '1 = inicio'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancelar'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(
+                context,
+                int.tryParse(posCtl.text) ?? current.length + 1,
+              ),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
       final repo = WorkoutPlanRepositoryImpl();
       await AddExerciseToPlanUseCase(repo)(
         widget.planId,
@@ -56,6 +86,7 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
           weight: 0,
           restSeconds: 90,
         ),
+        position: ((index ?? (current.length + 1)) - 1).clamp(0, current.length),
       );
       await _refresh();
     }

--- a/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/plan_exercise_details_provider.dart';
+import '../providers/exercises_provider.dart';
+import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../domain/entities/plan_exercise_detail.dart';
+import '../../domain/entities/exercise.dart';
+import '../../domain/usecases/add_exercise_to_plan_usecase.dart';
+import '../../domain/usecases/update_exercise_in_plan_usecase.dart';
+import '../../domain/usecases/delete_exercise_from_plan_usecase.dart';
+import 'select_exercise_screen.dart';
+
+class EditRoutineScreen extends ConsumerStatefulWidget {
+  final int planId;
+  const EditRoutineScreen({required this.planId, super.key});
+
+  @override
+  ConsumerState<EditRoutineScreen> createState() => _EditRoutineScreenState();
+}
+
+class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
+  late Future<List<PlanExerciseDetail>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = ref.read(planExerciseDetailsProvider(widget.planId).future);
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _future = ref.read(planExerciseDetailsProvider(widget.planId).future);
+    });
+  }
+
+  Future<void> _addExercise() async {
+    final all = await ref.read(allExercisesProvider.future);
+    final exercise = await Navigator.push<Exercise>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SelectExerciseScreen(
+          groups: {for (var e in all) e.mainMuscleGroup},
+        ),
+      ),
+    );
+    if (exercise != null) {
+      final repo = WorkoutPlanRepositoryImpl();
+      await AddExerciseToPlanUseCase(repo)(
+        widget.planId,
+        PlanExerciseDetail(
+          exerciseId: exercise.id,
+          name: exercise.name,
+          description: exercise.description,
+          sets: 3,
+          reps: 10,
+          weight: 0,
+          restSeconds: 90,
+        ),
+      );
+      await _refresh();
+    }
+  }
+
+  Future<void> _updateDetail(PlanExerciseDetail detail) async {
+    final repo = WorkoutPlanRepositoryImpl();
+    await UpdateExerciseInPlanUseCase(repo)(widget.planId, detail);
+  }
+
+  Future<void> _deleteDetail(int exerciseId) async {
+    final repo = WorkoutPlanRepositoryImpl();
+    await DeleteExerciseFromPlanUseCase(repo)(widget.planId, exerciseId);
+    await _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Editar rutina')),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _addExercise,
+        child: const Icon(Icons.add),
+      ),
+      body: FutureBuilder<List<PlanExerciseDetail>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final details = snapshot.data ?? [];
+          if (details.isEmpty) {
+            return const Center(child: Text('Sin ejercicios'));
+          }
+          return ListView.builder(
+            itemCount: details.length,
+            itemBuilder: (_, i) {
+              final d = details[i];
+              final setsCtl = TextEditingController(text: d.sets.toString());
+              final repsCtl = TextEditingController(text: d.reps.toString());
+              final weightCtl = TextEditingController(text: d.weight.toString());
+              final restCtl = TextEditingController(text: d.restSeconds.toString());
+              return Card(
+                margin: const EdgeInsets.all(8),
+                child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Expanded(child: Text(d.name, style: const TextStyle(fontWeight: FontWeight.w600))),
+                          IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () => _deleteDetail(d.exerciseId),
+                          ),
+                        ],
+                      ),
+                      Row(
+                        children: [
+                          _numField('Sets', setsCtl),
+                          const SizedBox(width: 8),
+                          _numField('Reps', repsCtl),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          _numField('Kg', weightCtl),
+                          const SizedBox(width: 8),
+                          _numField('Desc (s)', restCtl),
+                        ],
+                      ),
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton(
+                          onPressed: () {
+                            final newDetail = d.copyWith(
+                              sets: int.tryParse(setsCtl.text) ?? d.sets,
+                              reps: int.tryParse(repsCtl.text) ?? d.reps,
+                              weight: double.tryParse(weightCtl.text) ?? d.weight,
+                              restSeconds: int.tryParse(restCtl.text) ?? d.restSeconds,
+                            );
+                            _updateDetail(newDetail);
+                          },
+                          child: const Text('Guardar'),
+                        ),
+                      )
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _numField(String label, TextEditingController ctl) {
+    return Expanded(
+      child: TextField(
+        controller: ctl,
+        keyboardType: TextInputType.number,
+        decoration: InputDecoration(labelText: label),
+      ),
+    );
+  }
+}

--- a/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
@@ -28,8 +28,10 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
   }
 
   Future<void> _refresh() async {
+    final provider = planExerciseDetailsProvider(widget.planId);
+    ref.invalidate(provider);
     setState(() {
-      _future = ref.read(planExerciseDetailsProvider(widget.planId).future);
+      _future = ref.read(provider.future);
     });
   }
 
@@ -95,6 +97,7 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
   Future<void> _updateDetail(PlanExerciseDetail detail) async {
     final repo = WorkoutPlanRepositoryImpl();
     await UpdateExerciseInPlanUseCase(repo)(widget.planId, detail);
+    await _refresh();
   }
 
   Future<void> _deleteDetail(int exerciseId) async {

--- a/lib/src/features/routines/presentation/pages/routines_screen.dart
+++ b/lib/src/features/routines/presentation/pages/routines_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../routines/presentation/providers/workout_plan_provider.dart';
-import '../pages/exercises_screen.dart'; // Nueva pantalla
-import '../widgets/add_routine_button.dart'; // importar botón
+import '../pages/exercises_screen.dart';
+import '../pages/edit_routine_screen.dart';
+import '../widgets/add_routine_button.dart';
 
 class RoutinesScreen extends ConsumerWidget {
   static const routeName = '/routines';
@@ -25,6 +26,17 @@ class RoutinesScreen extends ConsumerWidget {
               leading: Text(plan.id.toString()),
               title: Text(plan.name),
               subtitle: Text(plan.frequency),
+              trailing: IconButton(
+                icon: const Icon(Icons.edit),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => EditRoutineScreen(planId: plan.id),
+                    ),
+                  );
+                },
+              ),
               onTap: () {
                 Navigator.push(
                   context,


### PR DESCRIPTION
## Summary
- extend workout plan repository with CRUD for plan exercises
- implement repository methods to modify `plan_exercise.xlsx`
- add use cases for adding, updating and deleting exercises in a plan
- add edit routine screen and link from routines list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686187965d9c83318d85fb1f08ed8198