### PR TITLE
Add exercise creation from routine editor

### DIFF
--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -161,6 +161,29 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
   }
 
   @override
+  Future<void> createExercise(
+    String name,
+    String description,
+    String category,
+    String mainMuscleGroup,
+  ) async {
+    final exFile = await _getOrCreateFile('exercise.xlsx');
+    final excel = Excel.decodeBytes(await exFile.readAsBytes());
+    final sheet = excel[kTableSchemas['exercise.xlsx']!.sheetName]!;
+
+    sheet.appendRow([
+      IntCellValue(_getLastId(sheet) + 1),
+      TextCellValue(name),
+      TextCellValue(description),
+      TextCellValue(category),
+      TextCellValue(mainMuscleGroup),
+    ]);
+
+    await exFile.writeAsBytes(excel.save()!);
+    _exerciseCache = null; // reset cache
+  }
+
+  @override
   Future<List<Exercise>> getSimilarExercises(int exerciseId) async {
     final all = await getAllExercises();
     final base = all.firstWhere((e) => e.id == exerciseId, orElse: () => Exercise(id: 0, name: '', description: '', category: '', mainMuscleGroup: ''));

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -184,6 +184,45 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
   }
 
   @override
+  Future<void> updateExercise(
+    int id,
+    String name,
+    String description,
+    String category,
+    String mainMuscleGroup,
+  ) async {
+    final file = await _getOrCreateFile('exercise.xlsx');
+    final excel = Excel.decodeBytes(await file.readAsBytes());
+    final sheet = excel[kTableSchemas['exercise.xlsx']!.sheetName]!;
+
+    for (var i = 1; i < sheet.rows.length; i++) {
+      final row = sheet.rows[i];
+      if (row.isNotEmpty && _cast<int>(row[0]) == id) {
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 1, rowIndex: i),
+          TextCellValue(name),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 2, rowIndex: i),
+          TextCellValue(description),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 3, rowIndex: i),
+          TextCellValue(category),
+        );
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(columnIndex: 4, rowIndex: i),
+          TextCellValue(mainMuscleGroup),
+        );
+        break;
+      }
+    }
+
+    await file.writeAsBytes(excel.save()!);
+    _exerciseCache = null; // reset cache
+  }
+
+  @override
   Future<List<Exercise>> getSimilarExercises(int exerciseId) async {
     final all = await getAllExercises();
     final base = all.firstWhere((e) => e.id == exerciseId, orElse: () => Exercise(id: 0, name: '', description: '', category: '', mainMuscleGroup: ''));

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -33,11 +33,13 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
   }
 
   int _getLastId(Sheet sheet) {
-    for (var i = sheet.rows.length - 1; i >= 1; i--) {
+    var maxId = 0;
+    for (var i = 1; i < sheet.rows.length; i++) {
       final val = sheet.rows[i][0]?.value;
-      if (val != null) return int.tryParse(val.toString()) ?? 0;
+      final id = int.tryParse(val?.toString() ?? '');
+      if (id != null && id > maxId) maxId = id;
     }
-    return 0;
+    return maxId;
   }
   T? _cast<T>(Data? cell) {
     final v = cell?.value;

--- a/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
+++ b/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
@@ -10,6 +10,12 @@ abstract class WorkoutPlanRepository {
   Future<List<Exercise>> getExercisesForPlan(int planId);
   Future<List<Exercise>> getAllExercises();
   Future<List<Exercise>> getSimilarExercises(int exerciseId);
+  Future<void> createExercise(
+    String name,
+    String description,
+    String category,
+    String mainMuscleGroup,
+  );
   Future<void> createWorkoutPlan(String name, String frequency);
   Future<List<PlanExerciseDetail>> getPlanExerciseDetails(int planId);
 

--- a/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
+++ b/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
@@ -16,6 +16,13 @@ abstract class WorkoutPlanRepository {
     String category,
     String mainMuscleGroup,
   );
+  Future<void> updateExercise(
+    int id,
+    String name,
+    String description,
+    String category,
+    String mainMuscleGroup,
+  );
   Future<void> createWorkoutPlan(String name, String frequency);
   Future<List<PlanExerciseDetail>> getPlanExerciseDetails(int planId);
 

--- a/lib/src/features/routines/domain/usecases/create_exercise_usecase.dart
+++ b/lib/src/features/routines/domain/usecases/create_exercise_usecase.dart
@@ -1,0 +1,15 @@
+import '../repositories/workout_plan_repository.dart';
+
+class CreateExerciseUseCase {
+  final WorkoutPlanRepository _repo;
+  const CreateExerciseUseCase(this._repo);
+
+  Future<void> call(
+    String name,
+    String description,
+    String category,
+    String mainMuscleGroup,
+  ) {
+    return _repo.createExercise(name, description, category, mainMuscleGroup);
+  }
+}

--- a/lib/src/features/routines/domain/usecases/update_exercise_usecase.dart
+++ b/lib/src/features/routines/domain/usecases/update_exercise_usecase.dart
@@ -1,0 +1,17 @@
+import '../repositories/workout_plan_repository.dart';
+
+class UpdateExerciseUseCase {
+  final WorkoutPlanRepository _repo;
+  const UpdateExerciseUseCase(this._repo);
+
+  Future<void> call(
+    int id,
+    String name,
+    String description,
+    String category,
+    String mainMuscleGroup,
+  ) {
+    return _repo.updateExercise(id, name, description, category, mainMuscleGroup);
+  }
+}
+

--- a/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
@@ -8,6 +8,7 @@ import '../../domain/entities/exercise.dart';
 import '../../domain/usecases/add_exercise_to_plan_usecase.dart';
 import '../../domain/usecases/update_exercise_in_plan_usecase.dart';
 import '../../domain/usecases/delete_exercise_from_plan_usecase.dart';
+import '../../domain/usecases/create_exercise_usecase.dart';
 import 'select_exercise_screen.dart';
 
 class EditRoutineScreen extends ConsumerStatefulWidget {
@@ -94,6 +95,65 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
     }
   }
 
+  Future<void> _createExercise() async {
+    final nameCtl = TextEditingController();
+    final descCtl = TextEditingController();
+    final catCtl = TextEditingController();
+    final groupCtl = TextEditingController();
+
+    final save = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Nuevo ejercicio'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: nameCtl,
+                decoration: const InputDecoration(labelText: 'Nombre'),
+              ),
+              TextField(
+                controller: descCtl,
+                decoration: const InputDecoration(labelText: 'Descripción'),
+              ),
+              TextField(
+                controller: catCtl,
+                decoration: const InputDecoration(labelText: 'Categoría'),
+              ),
+              TextField(
+                controller: groupCtl,
+                decoration:
+                    const InputDecoration(labelText: 'Músculo principal'),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Guardar'),
+          ),
+        ],
+      ),
+    );
+
+    if (save == true) {
+      final repo = WorkoutPlanRepositoryImpl();
+      await CreateExerciseUseCase(repo)(
+        nameCtl.text.trim(),
+        descCtl.text.trim(),
+        catCtl.text.trim(),
+        groupCtl.text.trim(),
+      );
+      ref.invalidate(allExercisesProvider);
+    }
+  }
+
   Future<void> _updateDetail(PlanExerciseDetail detail) async {
     final repo = WorkoutPlanRepositoryImpl();
     await UpdateExerciseInPlanUseCase(repo)(widget.planId, detail);
@@ -109,7 +169,15 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Editar rutina')),
+      appBar: AppBar(
+        title: const Text('Editar rutina'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.fitness_center),
+            onPressed: _createExercise,
+          ),
+        ],
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: _addExercise,
         child: const Icon(Icons.add),

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -256,20 +256,17 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
       '${d.inMinutes.remainder(60).toString().padLeft(2, '0')}:${d.inSeconds.remainder(60).toString().padLeft(2, '0')}';
 
   Future<void> _swapExercise(int index) async {
-    if (_sessionDetails == null) return;
+    if (_sessionDetails == null || _exerciseMap == null) return;
     final detail = _sessionDetails![index];
-    final alternatives = await ref.read(similarExercisesProvider(detail.exerciseId).future);
-    if (alternatives.isEmpty) return;
-    final picked = await showModalBottomSheet<Exercise>(
-      context: context,
-      builder: (_) => ListView(
-        children: alternatives
-            .map((e) => ListTile(
-                  title: Text(e.name),
-                  subtitle: Text('${e.category} • ${e.mainMuscleGroup}'),
-                  onTap: () => Navigator.pop(context, e),
-                ))
-            .toList(),
+    final groups = <String>{};
+    for (final d in _sessionDetails!) {
+      final g = _exerciseMap![d.exerciseId]?.mainMuscleGroup;
+      if (g != null) groups.add(g);
+    }
+    final picked = await Navigator.push<Exercise>(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SelectExerciseScreen(groups: groups),
       ),
     );
     if (picked != null) {


### PR DESCRIPTION
## Summary
- add `createExercise` to WorkoutPlanRepository and implement it
- add `CreateExerciseUseCase`
- allow creating new exercises from EditRoutineScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68631507ca088331bef9d973d7cf9d22