### PR TITLE
fix: align sqlite sync with excel schema

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'src/data/create/initialize_xlsx.dart';
+import 'src/data/sqlite/app_database.dart';
+import 'src/data/services/excel_sync_service.dart';
 import 'src/app.dart';
 import 'src/utils/notification_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await XlsxInitializer.ensureXlsxFilesExist();
+  final db = await AppDatabase.instance;
+  await ExcelSyncService(db).migrateFromExcel();
   await NotificationService.init();
-  runApp(
-    const ProviderScope(
-      child: MyApp(),
-    ),
-  );
+  runApp(const ProviderScope(child: MyApp()));
 }

--- a/lib/src/data/services/excel_sync_service.dart
+++ b/lib/src/data/services/excel_sync_service.dart
@@ -1,0 +1,337 @@
+import 'dart:io';
+
+import 'package:excel/excel.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../create/initialize_xlsx.dart';
+import '../schema/schemas.dart';
+
+/// Internal configuration describing how an Excel worksheet maps to a database
+/// table.
+class _TableConfig {
+  const _TableConfig({
+    required this.tableName,
+    required this.headerToColumn,
+    this.orderBy,
+    this.parsers = const {},
+  });
+
+  final String tableName;
+  final Map<String, String> headerToColumn;
+  final String? orderBy;
+  final Map<String, Object? Function(Object?)> parsers;
+
+  List<String> orderedColumns(TableSchema schema) =>
+      schema.headers.map((h) => headerToColumn[h]!).toList();
+}
+
+/// Service to sync data between SQLite and Excel files.
+class ExcelSyncService {
+  ExcelSyncService(this.db);
+
+  final Database db;
+
+  static final Map<String, _TableConfig> _tables = {
+    'exercise.xlsx': _TableConfig(
+      tableName: 'exercise',
+      orderBy: 'id',
+      headerToColumn: const {
+        'exercise_id': 'id',
+        'name': 'name',
+        'description': 'description',
+        'category': 'category',
+        'main_muscle_group': 'main_muscle_group',
+      },
+      parsers: const {
+        'id': _parseInt,
+        'name': _parseString,
+        'description': _parseString,
+        'category': _parseString,
+        'main_muscle_group': _parseString,
+      },
+    ),
+    'workout_plan.xlsx': _TableConfig(
+      tableName: 'workout_plan',
+      orderBy: 'id',
+      headerToColumn: const {
+        'plan_id': 'id',
+        'name': 'name',
+        'frequency': 'frequency',
+      },
+      parsers: const {
+        'id': _parseInt,
+        'name': _parseString,
+        'frequency': _parseString,
+      },
+    ),
+    'plan_exercise.xlsx': _TableConfig(
+      tableName: 'plan_exercise',
+      orderBy: 'plan_id ASC, position ASC',
+      headerToColumn: const {
+        'plan_id': 'plan_id',
+        'exercise_id': 'exercise_id',
+        'suggested_sets': 'suggested_sets',
+        'suggested_reps': 'suggested_reps',
+        'estimated_weight': 'estimated_weight',
+        'rest_seconds': 'rest_seconds',
+        'image_path': 'image_path',
+      },
+      parsers: const {
+        'plan_id': _parseInt,
+        'exercise_id': _parseInt,
+        'suggested_sets': _parseInt,
+        'suggested_reps': _parseInt,
+        'estimated_weight': _parseDouble,
+        'rest_seconds': _parseInt,
+        'image_path': _parseString,
+      },
+    ),
+    'workout_session.xlsx': _TableConfig(
+      tableName: 'workout_session',
+      orderBy: 'date',
+      headerToColumn: const {
+        'session_id': 'id',
+        'date': 'date',
+        'plan_id': 'plan_id',
+        'fatigue_level': 'fatigue_level',
+        'duration_minutes': 'duration_minutes',
+        'mood': 'mood',
+        'notes': 'notes',
+      },
+      parsers: const {
+        'id': _parseInt,
+        'date': _parseDate,
+        'plan_id': _parseInt,
+        'fatigue_level': _parseString,
+        'duration_minutes': _parseInt,
+        'mood': _parseString,
+        'notes': _parseString,
+      },
+    ),
+    'workout_log.xlsx': _TableConfig(
+      tableName: 'workout_log',
+      orderBy: 'date',
+      headerToColumn: const {
+        'log_id': 'id',
+        'date': 'date',
+        'plan_id': 'plan_id',
+        'exercise_id': 'exercise_id',
+        'set_number': 'set_number',
+        'reps_completed': 'reps',
+        'weight_used': 'weight',
+        'RIR': 'rir',
+      },
+      parsers: const {
+        'id': _parseInt,
+        'date': _parseDate,
+        'plan_id': _parseInt,
+        'exercise_id': _parseInt,
+        'set_number': _parseInt,
+        'reps': _parseInt,
+        'weight': _parseDouble,
+        'rir': _parseInt,
+      },
+    ),
+  };
+
+  /// Exports the current database contents to `.xlsx` files.
+  Future<void> exportToExcel() async {
+    final dir = await getApplicationDocumentsDirectory();
+    for (final entry in _tables.entries) {
+      final schema = kTableSchemas[entry.key];
+      if (schema == null) continue;
+      final config = entry.value;
+      final columns = config.orderedColumns(schema);
+      final rows = await db.query(
+        config.tableName,
+        columns: columns,
+        orderBy: config.orderBy,
+      );
+      final excel = Excel.createExcel();
+      final defaultSheet = excel.getDefaultSheet();
+      if (defaultSheet != null) {
+        excel.rename(defaultSheet, schema.sheetName);
+      }
+      final sheet = excel[schema.sheetName]!;
+      sheet.appendRow(
+        schema.headers.map<CellValue?>((e) => TextCellValue(e)).toList(),
+      );
+      for (final row in rows) {
+        final values = schema.headers.map<CellValue?>((header) {
+          final column = config.headerToColumn[header]!;
+          final value = row[column];
+          return _toCellValue(value);
+        }).toList();
+        sheet.appendRow(values);
+      }
+      final file = File('${dir.path}/${entry.key}');
+      final bytes = excel.save();
+      if (bytes != null) {
+        await file.create(recursive: true);
+        await file.writeAsBytes(bytes, flush: true);
+      }
+    }
+  }
+
+  /// Imports data from existing `.xlsx` files into the database.
+  Future<void> importFromExcel() async {
+    final dir = await getApplicationDocumentsDirectory();
+    await db.transaction((txn) async {
+      for (final entry in _tables.entries) {
+        final schema = kTableSchemas[entry.key];
+        if (schema == null) continue;
+        final config = entry.value;
+        final file = File('${dir.path}/${entry.key}');
+        if (!await file.exists()) continue;
+        final bytes = await file.readAsBytes();
+        final excel = Excel.decodeBytes(bytes);
+        final sheet = excel[schema.sheetName];
+        if (sheet == null) continue;
+
+        await txn.delete(config.tableName);
+        final batch = txn.batch();
+        final positions = <int, int>{};
+
+        for (var i = 1; i < sheet.rows.length; i++) {
+          final row = sheet.rows[i];
+          if (_isRowEmpty(row)) continue;
+
+          final values = <String, Object?>{};
+          for (var c = 0; c < schema.headers.length && c < row.length; c++) {
+            final header = schema.headers[c];
+            final column = config.headerToColumn[header];
+            if (column == null) continue;
+            final parser = config.parsers[column];
+            final parsedValue = parser != null
+                ? parser(row[c]?.value)
+                : _defaultParse(row[c]?.value);
+            values[column] = parsedValue;
+          }
+
+          if (values.isEmpty) {
+            continue;
+          }
+
+          if (config.tableName == 'plan_exercise') {
+            final planId = values['plan_id'] as int?;
+            final exerciseId = values['exercise_id'] as int?;
+            if (planId == null || exerciseId == null) {
+              continue;
+            }
+            final pos = positions.update(planId, (value) => value + 1,
+                ifAbsent: () => 0);
+            values['position'] = pos;
+          }
+
+          if (values.containsKey('id') && values['id'] == null) {
+            values.remove('id');
+          }
+
+          batch.insert(
+            config.tableName,
+            values,
+            conflictAlgorithm: ConflictAlgorithm.replace,
+          );
+        }
+
+        await batch.commit(noResult: true);
+      }
+    });
+  }
+
+  /// Migrates legacy Excel data into SQLite on first launch.
+  Future<void> migrateFromExcel() async {
+    await XlsxInitializer.ensureXlsxFilesExist();
+    final tables = _tables.values.map((e) => e.tableName);
+    for (final table in tables) {
+      final count = Sqflite.firstIntValue(
+        await db.rawQuery('SELECT COUNT(*) FROM $table'),
+      );
+      if (count != null && count > 0) {
+        return;
+      }
+    }
+    await importFromExcel();
+  }
+}
+
+bool _isRowEmpty(List<Data?> row) {
+  for (final cell in row) {
+    final value = cell?.value;
+    if (value == null) {
+      continue;
+    }
+    if (value is String && value.trim().isEmpty) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+CellValue? _toCellValue(Object? value) {
+  if (value == null) return null;
+  if (value is int) return IntCellValue(value);
+  if (value is double) return DoubleCellValue(value);
+  if (value is num) return DoubleCellValue(value.toDouble());
+  if (value is DateTime) {
+    return TextCellValue(_formatDate(value));
+  }
+  return TextCellValue(value.toString());
+}
+
+Object? _defaultParse(Object? value) => value;
+
+Object? _parseInt(Object? value) {
+  if (value == null) return null;
+  if (value is int) return value;
+  if (value is double) return value.toInt();
+  final str = value.toString().trim();
+  if (str.isEmpty) return null;
+  return int.tryParse(str);
+}
+
+Object? _parseDouble(Object? value) {
+  if (value == null) return null;
+  if (value is double) return value;
+  if (value is int) return value.toDouble();
+  final str = value.toString().trim();
+  if (str.isEmpty) return null;
+  return double.tryParse(str);
+}
+
+Object? _parseString(Object? value) {
+  if (value == null) return '';
+  return value.toString();
+}
+
+Object? _parseDate(Object? value) {
+  if (value == null) return null;
+  if (value is DateTime) return _formatDate(value);
+  if (value is num) {
+    final numeric = value.toInt();
+    final digits = numeric.toString();
+    if (digits.length == 8) {
+      final maybeDate = DateTime.tryParse(
+          '${digits.substring(0, 4)}-${digits.substring(4, 6)}-${digits.substring(6, 8)}');
+      if (maybeDate != null) {
+        return _formatDate(maybeDate);
+      }
+    }
+    final base = DateTime(1899, 12, 30);
+    final date = base.add(Duration(
+      milliseconds: (value * Duration.millisecondsPerDay).round(),
+    ));
+    return _formatDate(date);
+  }
+  final str = value.toString().trim();
+  if (str.isEmpty) return null;
+  final parsed = DateTime.tryParse(str);
+  if (parsed != null) {
+    return _formatDate(parsed);
+  }
+  return str;
+}
+
+String _formatDate(DateTime value) => value.toIso8601String().split('T').first;

--- a/lib/src/data/sqlite/app_database.dart
+++ b/lib/src/data/sqlite/app_database.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Singleton wrapper around the SQLite [Database].
+class AppDatabase {
+  AppDatabase._internal();
+  static final AppDatabase _instance = AppDatabase._internal();
+  static Database? _db;
+
+  /// Returns the opened database, creating it if necessary.
+  static Future<Database> get instance async {
+    if (_db != null) return _db!;
+    final dir = await getApplicationDocumentsDirectory();
+    final path = p.join(dir.path, 'fitlog.db');
+    _db = await openDatabase(
+      path,
+      version: 1,
+      onConfigure: (db) async {
+        await db.execute('PRAGMA foreign_keys = ON');
+      },
+      onCreate: (db, _) async {
+        await db.execute('''
+          CREATE TABLE exercise(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            description TEXT,
+            category TEXT,
+            main_muscle_group TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE workout_plan(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            frequency TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE plan_exercise(
+            plan_id INTEGER,
+            exercise_id INTEGER,
+            suggested_sets INTEGER,
+            suggested_reps INTEGER,
+            estimated_weight REAL,
+            rest_seconds INTEGER,
+            image_path TEXT,
+            position INTEGER,
+            PRIMARY KEY(plan_id, exercise_id)
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE workout_session(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT,
+            plan_id INTEGER,
+            fatigue_level TEXT,
+            duration_minutes INTEGER,
+            mood TEXT,
+            notes TEXT
+          );
+        ''');
+        await db.execute('''
+          CREATE TABLE workout_log(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT,
+            plan_id INTEGER,
+            exercise_id INTEGER,
+            set_number INTEGER,
+            reps INTEGER,
+            weight REAL,
+            rir INTEGER
+          );
+        ''');
+      },
+    );
+    return _db!;
+  }
+}

--- a/lib/src/features/app_data/data/repositories/app_data_repository_impl.dart
+++ b/lib/src/features/app_data/data/repositories/app_data_repository_impl.dart
@@ -5,12 +5,16 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
 import '../../../../data/schema/schemas.dart';
+import '../../../../data/sqlite/app_database.dart';
+import '../../../../data/services/excel_sync_service.dart';
 import '../../domain/repositories/app_data_repository.dart';
 
 class AppDataRepositoryImpl implements AppDataRepository {
   @override
   Future<File> exportData() async {
     final dir = await getApplicationDocumentsDirectory();
+    final db = await AppDatabase.instance;
+    await ExcelSyncService(db).exportToExcel();
     final archive = Archive();
     for (final filename in kTableSchemas.keys) {
       final file = File(p.join(dir.path, filename));
@@ -48,6 +52,8 @@ class AppDataRepositoryImpl implements AppDataRepository {
     if (ext == '.xlsx') {
       final outFile = File(p.join(dir.path, p.basename(file.path)));
       await outFile.writeAsBytes(await file.readAsBytes(), flush: true);
+      final db = await AppDatabase.instance;
+      await ExcelSyncService(db).importFromExcel();
       return;
     }
 
@@ -60,5 +66,7 @@ class AppDataRepositoryImpl implements AppDataRepository {
       final outFile = File(outPath);
       await outFile.writeAsBytes(archived.content as List<int>, flush: true);
     }
+    final db = await AppDatabase.instance;
+    await ExcelSyncService(db).importFromExcel();
   }
 }

--- a/lib/src/features/history/data/repositories/workout_history_repository_sqlite.dart
+++ b/lib/src/features/history/data/repositories/workout_history_repository_sqlite.dart
@@ -1,0 +1,44 @@
+import 'package:sqflite/sqflite.dart';
+import '../../../../data/sqlite/app_database.dart';
+import '../../../routines/domain/entities/workout_log_entry.dart';
+import '../../../routines/domain/entities/workout_session.dart';
+import '../../domain/repositories/workout_history_repository.dart';
+
+class WorkoutHistoryRepositorySqlite implements WorkoutHistoryRepository {
+  Future<Database> get _db async => AppDatabase.instance;
+
+  @override
+  Future<List<WorkoutSession>> getAllSessions() async {
+    final db = await _db;
+    final rows = await db.query('workout_session', orderBy: 'date');
+    return rows
+        .map((r) => WorkoutSession(
+              planId: (r['plan_id'] as int?) ?? 0,
+              date: DateTime.tryParse((r['date'] as String?) ?? '') ??
+                  DateTime.fromMillisecondsSinceEpoch(0),
+              fatigueLevel: (r['fatigue_level'] as String?) ?? '',
+              durationMinutes: (r['duration_minutes'] as int?) ?? 0,
+              mood: (r['mood'] as String?) ?? '',
+              notes: (r['notes'] as String?) ?? '',
+            ))
+        .toList();
+  }
+
+  @override
+  Future<List<WorkoutLogEntry>> getAllLogs() async {
+    final db = await _db;
+    final rows = await db.query('workout_log', orderBy: 'date');
+    return rows
+        .map((r) => WorkoutLogEntry(
+              date: DateTime.tryParse((r['date'] as String?) ?? '') ??
+                  DateTime.fromMillisecondsSinceEpoch(0),
+              planId: (r['plan_id'] as int?) ?? 0,
+              exerciseId: (r['exercise_id'] as int?) ?? 0,
+              setNumber: (r['set_number'] as int?) ?? 0,
+              reps: (r['reps'] as int?) ?? 0,
+              weight: (r['weight'] as num?)?.toDouble() ?? 0,
+              rir: (r['rir'] as int?) ?? 0,
+            ))
+        .toList();
+  }
+}

--- a/lib/src/features/history/presentation/providers/history_providers.dart
+++ b/lib/src/features/history/presentation/providers/history_providers.dart
@@ -1,11 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../data/repositories/workout_history_repository_impl.dart';
+import '../../data/repositories/workout_history_repository_sqlite.dart';
 import '../../domain/usecases/get_workout_sessions_usecase.dart';
 import '../../domain/usecases/get_workout_logs_usecase.dart';
 import '../../../routines/domain/entities/workout_log_entry.dart';
 import '../../../routines/domain/entities/workout_session.dart';
 
-final _repoProvider = Provider((_) => WorkoutHistoryRepositoryImpl());
+final _repoProvider = Provider((_) => WorkoutHistoryRepositorySqlite());
 
 // Provides all workout sessions
 final workoutSessionsProvider =

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_sqlite.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_sqlite.dart
@@ -1,0 +1,222 @@
+import 'package:sqflite/sqflite.dart';
+import '../../../../data/sqlite/app_database.dart';
+import '../../domain/entities/exercise.dart';
+import '../../domain/entities/plan_exercise_detail.dart';
+import '../../domain/entities/workout_log_entry.dart';
+import '../../domain/entities/workout_plan.dart';
+import '../../domain/entities/workout_session.dart';
+import '../../domain/repositories/workout_plan_repository.dart';
+
+class WorkoutPlanRepositorySqlite implements WorkoutPlanRepository {
+  Future<Database> get _db async => AppDatabase.instance;
+
+  Exercise _mapExercise(Map<String, Object?> row) => Exercise(
+        id: (row['id'] as int?) ?? 0,
+        name: (row['name'] as String?) ?? '',
+        description: (row['description'] as String?) ?? '',
+        category: (row['category'] as String?) ?? '',
+        mainMuscleGroup: (row['main_muscle_group'] as String?) ?? '',
+      );
+
+  @override
+  Future<List<WorkoutPlan>> getAllPlans() async {
+    final db = await _db;
+    final rows = await db.query('workout_plan', orderBy: 'id');
+    return rows
+        .map((r) => WorkoutPlan(
+              id: (r['id'] as int?) ?? 0,
+              name: (r['name'] as String?) ?? '',
+              frequency: (r['frequency'] as String?) ?? '',
+            ))
+        .toList();
+  }
+
+  @override
+  Future<List<Exercise>> getExercisesForPlan(int planId) async {
+    final db = await _db;
+    final rows = await db.rawQuery('''
+      SELECT e.* FROM plan_exercise pe
+      JOIN exercise e ON e.id = pe.exercise_id
+      WHERE pe.plan_id = ?
+      ORDER BY pe.position
+    ''', [planId]);
+    return rows.map(_mapExercise).toList();
+  }
+
+  @override
+  Future<List<Exercise>> getAllExercises() async {
+    final db = await _db;
+    final rows = await db.query('exercise', orderBy: 'name');
+    return rows.map(_mapExercise).toList();
+  }
+
+  @override
+  Future<List<Exercise>> getSimilarExercises(int exerciseId) async {
+    final db = await _db;
+    final group = await db.query('exercise',
+        columns: ['main_muscle_group'], where: 'id = ?', whereArgs: [exerciseId]);
+    if (group.isEmpty) return [];
+    final rows = await db.query('exercise',
+        where: 'main_muscle_group = ? AND id != ?',
+        whereArgs: [group.first['main_muscle_group'], exerciseId]);
+    return rows.map(_mapExercise).toList();
+  }
+
+  @override
+  Future<void> createExercise(
+      String name, String description, String category, String group) async {
+    final db = await _db;
+    await db.insert('exercise', {
+      'name': name,
+      'description': description,
+      'category': category,
+      'main_muscle_group': group,
+    });
+  }
+
+  @override
+  Future<void> updateExercise(int id, String name, String description,
+      String category, String group) async {
+    final db = await _db;
+    await db.update(
+      'exercise',
+      {
+        'name': name,
+        'description': description,
+        'category': category,
+        'main_muscle_group': group,
+      },
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+
+  @override
+  Future<void> createWorkoutPlan(String name, String frequency) async {
+    final db = await _db;
+    await db.insert('workout_plan', {
+      'name': name,
+      'frequency': frequency,
+    });
+  }
+
+  @override
+  Future<List<PlanExerciseDetail>> getPlanExerciseDetails(int planId) async {
+    final db = await _db;
+    final rows = await db.rawQuery('''
+      SELECT pe.*, e.name, e.description FROM plan_exercise pe
+      JOIN exercise e ON e.id = pe.exercise_id
+      WHERE pe.plan_id = ?
+      ORDER BY pe.position
+    ''', [planId]);
+    return rows
+        .map((r) => PlanExerciseDetail(
+              exerciseId: (r['exercise_id'] as int?) ?? 0,
+              name: (r['name'] as String?) ?? '',
+              description: (r['description'] as String?) ?? '',
+              sets: (r['suggested_sets'] as int?) ?? 0,
+              reps: (r['suggested_reps'] as int?) ?? 0,
+              weight: (r['estimated_weight'] as num?)?.toDouble() ?? 0,
+              restSeconds: (r['rest_seconds'] as int?) ?? 0,
+            ))
+        .toList();
+  }
+
+  @override
+  Future<void> addExerciseToPlan(int planId, PlanExerciseDetail detail,
+      {int? position}) async {
+    final db = await _db;
+    final maxPosRes = await db.rawQuery(
+      'SELECT MAX(position) as m FROM plan_exercise WHERE plan_id = ?',
+      [planId],
+    );
+    final maxPos = maxPosRes.first['m'] as int? ?? -1;
+    final insertPos = (position ?? maxPos + 1).clamp(0, maxPos + 1);
+    await db.transaction((txn) async {
+      await txn.rawUpdate(
+          'UPDATE plan_exercise SET position = position + 1 WHERE plan_id = ? AND position >= ?',
+          [planId, insertPos]);
+      await txn.insert('plan_exercise', {
+        'plan_id': planId,
+        'exercise_id': detail.exerciseId,
+        'suggested_sets': detail.sets,
+        'suggested_reps': detail.reps,
+        'estimated_weight': detail.weight,
+        'rest_seconds': detail.restSeconds,
+        'position': insertPos,
+        'image_path': null,
+      });
+    });
+  }
+
+  @override
+  Future<void> updateExerciseInPlan(int planId, PlanExerciseDetail detail) async {
+    final db = await _db;
+    await db.update(
+      'plan_exercise',
+      {
+        'suggested_sets': detail.sets,
+        'suggested_reps': detail.reps,
+        'estimated_weight': detail.weight,
+        'rest_seconds': detail.restSeconds,
+      },
+      where: 'plan_id = ? AND exercise_id = ?',
+      whereArgs: [planId, detail.exerciseId],
+    );
+  }
+
+  @override
+  Future<void> deleteExerciseFromPlan(int planId, int exerciseId) async {
+    final db = await _db;
+    await db.transaction((txn) async {
+      final posRes = await txn.query(
+        'plan_exercise',
+        columns: ['position'],
+        where: 'plan_id = ? AND exercise_id = ?',
+        whereArgs: [planId, exerciseId],
+      );
+      if (posRes.isEmpty) {
+        return;
+      }
+      final pos = posRes.first['position'] as int? ?? 0;
+      await txn.delete('plan_exercise',
+          where: 'plan_id = ? AND exercise_id = ?',
+          whereArgs: [planId, exerciseId]);
+      await txn.rawUpdate(
+          'UPDATE plan_exercise SET position = position - 1 WHERE plan_id = ? AND position > ?',
+          [planId, pos]);
+    });
+  }
+
+  @override
+  Future<void> saveWorkoutLogs(List<WorkoutLogEntry> logs) async {
+    if (logs.isEmpty) return;
+    final db = await _db;
+    final batch = db.batch();
+    for (final l in logs) {
+      batch.insert('workout_log', {
+        'date': l.date.toIso8601String().split('T').first,
+        'plan_id': l.planId,
+        'exercise_id': l.exerciseId,
+        'set_number': l.setNumber,
+        'reps': l.reps,
+        'weight': l.weight,
+        'rir': l.rir,
+      });
+    }
+    await batch.commit(noResult: true);
+  }
+
+  @override
+  Future<void> saveWorkoutSession(WorkoutSession s) async {
+    final db = await _db;
+    await db.insert('workout_session', {
+      'date': s.date.toIso8601String().split('T').first,
+      'plan_id': s.planId,
+      'fatigue_level': s.fatigueLevel,
+      'duration_minutes': s.durationMinutes,
+      'mood': s.mood,
+      'notes': s.notes,
+    });
+  }
+}

--- a/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/plan_exercise_details_provider.dart';
 import '../providers/exercises_provider.dart';
-import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../data/repositories/workout_plan_repository_sqlite.dart';
 import '../../domain/entities/plan_exercise_detail.dart';
 import '../../domain/entities/exercise.dart';
 import '../../domain/usecases/add_exercise_to_plan_usecase.dart';
@@ -78,7 +78,7 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
           ],
         ),
       );
-      final repo = WorkoutPlanRepositoryImpl();
+      final repo = WorkoutPlanRepositorySqlite();
       await AddExerciseToPlanUseCase(repo)(
         widget.planId,
         PlanExerciseDetail(
@@ -144,7 +144,7 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
     );
 
     if (save == true) {
-      final repo = WorkoutPlanRepositoryImpl();
+      final repo = WorkoutPlanRepositorySqlite();
       await CreateExerciseUseCase(repo)(
         nameCtl.text.trim(),
         descCtl.text.trim(),
@@ -216,7 +216,7 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
     );
 
     if (save == true) {
-      final repo = WorkoutPlanRepositoryImpl();
+      final repo = WorkoutPlanRepositorySqlite();
       await UpdateExerciseUseCase(repo)(
         ex.id,
         nameCtl.text.trim(),
@@ -230,13 +230,13 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
   }
 
   Future<void> _updateDetail(PlanExerciseDetail detail) async {
-    final repo = WorkoutPlanRepositoryImpl();
+    final repo = WorkoutPlanRepositorySqlite();
     await UpdateExerciseInPlanUseCase(repo)(widget.planId, detail);
     await _refresh();
   }
 
   Future<void> _deleteDetail(int exerciseId) async {
-    final repo = WorkoutPlanRepositoryImpl();
+    final repo = WorkoutPlanRepositorySqlite();
     await DeleteExerciseFromPlanUseCase(repo)(widget.planId, exerciseId);
     await _refresh();
   }

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -12,7 +12,7 @@ import '../../domain/entities/workout_log_entry.dart';
 import '../../domain/entities/workout_session.dart';
 import '../../domain/entities/exercise.dart';
 import '../../domain/entities/plan_exercise_detail.dart';
-import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../data/repositories/workout_plan_repository_sqlite.dart';
 import '../../domain/usecases/save_workout_logs_usecase.dart';
 import '../../domain/usecases/save_workout_session_usecase.dart';
 import '../widgets/exercise_tile.dart';
@@ -114,7 +114,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                   return;
                 }
                 if (!await _showFinishDialog(context)) return;
-                final repo = WorkoutPlanRepositoryImpl();
+                final repo = WorkoutPlanRepositorySqlite();
                 await SaveWorkoutLogsUseCase(repo)(notifier.completedLogs);
                 await SaveWorkoutSessionUseCase(repo)(
                   WorkoutSession(

--- a/lib/src/features/routines/presentation/providers/exercises_provider.dart
+++ b/lib/src/features/routines/presentation/providers/exercises_provider.dart
@@ -1,25 +1,25 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../data/repositories/workout_plan_repository_sqlite.dart';
 import '../../domain/usecases/get_exercises_for_plan_usecase.dart';
 import '../../domain/usecases/get_all_exercises_usecase.dart';
 import '../../domain/usecases/get_similar_exercises_usecase.dart';
 import '../../domain/entities/exercise.dart';
 
 final exercisesForPlanProvider = FutureProvider.family((ref, int planId) async {
-  final repo = WorkoutPlanRepositoryImpl();
+  final repo = WorkoutPlanRepositorySqlite();
   final usecase = GetExercisesForPlanUseCase(repo);
   return usecase(planId);
 });
 
 final allExercisesProvider = FutureProvider((ref) async {
-  final repo = WorkoutPlanRepositoryImpl();
+  final repo = WorkoutPlanRepositorySqlite();
   final usecase = GetAllExercisesUseCase(repo);
   return usecase();
 });
 
 final similarExercisesProvider =
     FutureProvider.family<List<Exercise>, int>((ref, int exerciseId) async {
-  final repo = WorkoutPlanRepositoryImpl();
+  final repo = WorkoutPlanRepositorySqlite();
   final usecase = GetSimilarExercisesUseCase(repo);
   return usecase(exerciseId);
 });

--- a/lib/src/features/routines/presentation/providers/plan_exercise_details_provider.dart
+++ b/lib/src/features/routines/presentation/providers/plan_exercise_details_provider.dart
@@ -1,10 +1,10 @@
 // lib/src/features/routines/presentation/providers/plan_exercise_details_provider.dart
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../data/repositories/workout_plan_repository_sqlite.dart';
 import '../../domain/usecases/get_plan_exercise_details_usecase.dart';
 
 final planExerciseDetailsProvider = FutureProvider.family((ref, int planId) async {
-  final repo = WorkoutPlanRepositoryImpl();
+  final repo = WorkoutPlanRepositorySqlite();
   final usecase = GetPlanExerciseDetailsUseCase(repo);
   return usecase(planId);
 });

--- a/lib/src/features/routines/presentation/providers/workout_plan_provider.dart
+++ b/lib/src/features/routines/presentation/providers/workout_plan_provider.dart
@@ -1,9 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../data/repositories/workout_plan_repository_sqlite.dart';
 import '../../domain/usecases/get_workout_plans_usecase.dart';
 
 final workoutPlanProvider = FutureProvider.autoDispose((ref) async {
-  final repo = WorkoutPlanRepositoryImpl();
+  final repo = WorkoutPlanRepositorySqlite();
   final usecase = GetWorkoutPlansUseCase(repo);
   return usecase();
 });

--- a/lib/src/features/routines/presentation/widgets/add_routine_button.dart
+++ b/lib/src/features/routines/presentation/widgets/add_routine_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../data/repositories/workout_plan_repository_sqlite.dart';
 import '../../domain/usecases/create_workout_plan_usecase.dart';
 import '../providers/workout_plan_provider.dart';
 
@@ -38,7 +38,7 @@ class AddRoutineButton extends ConsumerWidget {
               ),
               ElevatedButton(
                 onPressed: () async {
-                  final repo = WorkoutPlanRepositoryImpl();
+                  final repo = WorkoutPlanRepositorySqlite();
                   final usecase = CreateWorkoutPlanUseCase(repo);
                   await usecase(
                     nameController.text.trim(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   # 📦 Local Data Persistence
   path_provider: ^2.1.1
   excel: ^4.0.6 # To read/write .xlsx files
+  sqflite: ^2.3.0
+  path: ^1.9.0
   file_picker: 10.1.2
   permission_handler: ^11.3.0
   archive: ^3.4.9


### PR DESCRIPTION
## Summary
- map Excel headers to SQLite columns for import/export and ensure migrations seed data only once
- enable foreign keys and add plan exercise image paths in the SQLite schema
- harden SQLite repositories with null-safe conversions when reading sessions, logs, and exercises

## Testing
- `dart format lib/main.dart lib/src/data/sqlite/app_database.dart lib/src/data/services/excel_sync_service.dart lib/src/features/routines/data/repositories/workout_plan_repository_sqlite.dart lib/src/features/history/data/repositories/workout_history_repository_sqlite.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c211a3147c832387e7ad66057914b1