### PR TITLE
Add routine activation toggle and soft-delete support

### DIFF
--- a/lib/src/data/schema/schemas.dart
+++ b/lib/src/data/schema/schemas.dart
@@ -128,13 +128,15 @@ const Map<String, TableSchema> kTableSchemas = {
       'name',
       // e.g. “Mon-Wed-Fri”
       'frequency',
+      // Soft delete flag
+      'is_active',
     ],
     sample: [
-      [1, 'Upper Push (Strength)', 'Weekly Monday'],
-      [2, 'Lower A (Quads)', 'Weekly Tuesday'],
-      [3, 'Upper Pull (Width)', 'Weekly wensday'],
-      [4, 'Push-Pull Hybrid (Pump)', 'Weekly Friday '],
-      [5, 'Lower B (Posterior Chain)', 'Weekly saturda'],
+      [1, 'Upper Push (Strength)', 'Weekly Monday', 1],
+      [2, 'Lower A (Quads)', 'Weekly Tuesday', 1],
+      [3, 'Upper Pull (Width)', 'Weekly wensday', 1],
+      [4, 'Push-Pull Hybrid (Pump)', 'Weekly Friday ', 1],
+      [5, 'Lower B (Posterior Chain)', 'Weekly saturda', 1],
     ],
   ),
 

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -12,6 +12,7 @@ import '../../../../data/schema/schemas.dart';
 
 class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
   List<Exercise>? _exerciseCache;
+  static const int _planActiveColumnIndex = 3;
   Future<File> _getOrCreateFile(String filename) async {
     final dir = await getApplicationDocumentsDirectory();
     final file = File('${dir.path}/$filename');
@@ -40,6 +41,37 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
       if (id != null && id > maxId) maxId = id;
     }
     return maxId;
+  }
+
+  bool _parseActiveCell(Data? cell) {
+    final value = cell?.value;
+    if (value == null) return true;
+    if (value is bool) return value;
+    if (value is int) return value != 0;
+    final text = value.toString().toLowerCase();
+    return text != '0' && text != 'false' && text != 'no';
+  }
+
+  void _ensurePlanActiveColumn(Sheet sheet) {
+    if (sheet.rows.isEmpty) return;
+    final header = sheet.rows.first;
+    final hasColumn = header.length > _planActiveColumnIndex &&
+        header[_planActiveColumnIndex]?.value.toString() == 'is_active';
+    if (hasColumn) return;
+
+    sheet.updateCell(
+      CellIndex.indexByColumnRow(columnIndex: _planActiveColumnIndex, rowIndex: 0),
+      TextCellValue('is_active'),
+    );
+    for (var i = 1; i < sheet.rows.length; i++) {
+      sheet.updateCell(
+        CellIndex.indexByColumnRow(
+          columnIndex: _planActiveColumnIndex,
+          rowIndex: i,
+        ),
+        IntCellValue(1),
+      );
+    }
   }
   T? _cast<T>(Data? cell) {
     final v = cell?.value;
@@ -133,7 +165,15 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
           final id = int.tryParse(row[0]?.value.toString() ?? '0') ?? 0;
           final name = row[1]?.value.toString() ?? '';
           final frequency = row[2]?.value.toString() ?? '';
-          return WorkoutPlan(id: id, name: name, frequency: frequency);
+          final isActive = row.length > _planActiveColumnIndex
+              ? _parseActiveCell(row[_planActiveColumnIndex])
+              : true;
+          return WorkoutPlan(
+            id: id,
+            name: name,
+            frequency: frequency,
+            isActive: isActive,
+          );
         })
         .toList();
   }
@@ -143,12 +183,38 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
     final file = await _getOrCreateFile('workout_plan.xlsx');
     final excel = Excel.decodeBytes(await file.readAsBytes());
     final sheet = excel[kTableSchemas['workout_plan.xlsx']!.sheetName]!;
+    _ensurePlanActiveColumn(sheet);
 
     sheet.appendRow([
       IntCellValue(_getLastId(sheet) + 1),
       TextCellValue(name),
       TextCellValue(frequency),
+      IntCellValue(1),
     ]);
+    await file.writeAsBytes(excel.save()!);
+  }
+
+  @override
+  Future<void> setWorkoutPlanActive(int planId, bool isActive) async {
+    final file = await _getOrCreateFile('workout_plan.xlsx');
+    final excel = Excel.decodeBytes(await file.readAsBytes());
+    final sheet = excel[kTableSchemas['workout_plan.xlsx']!.sheetName]!;
+    _ensurePlanActiveColumn(sheet);
+
+    for (var i = 1; i < sheet.rows.length; i++) {
+      final row = sheet.rows[i];
+      if (row.isNotEmpty && _cast<int>(row[0]) == planId) {
+        sheet.updateCell(
+          CellIndex.indexByColumnRow(
+            columnIndex: _planActiveColumnIndex,
+            rowIndex: i,
+          ),
+          IntCellValue(isActive ? 1 : 0),
+        );
+        break;
+      }
+    }
+
     await file.writeAsBytes(excel.save()!);
   }
 

--- a/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
+++ b/lib/src/features/routines/data/repositories/workout_plan_repository_impl.dart
@@ -46,8 +46,9 @@ class WorkoutPlanRepositoryImpl implements WorkoutPlanRepository {
   bool _parseActiveCell(Data? cell) {
     final value = cell?.value;
     if (value == null) return true;
-    if (value is bool) return value;
-    if (value is int) return value != 0;
+    if (value is BoolCellValue) return value.value;
+    if (value is IntCellValue) return value.value != 0;
+    if (value is DoubleCellValue) return value.value != 0;
     final text = value.toString().toLowerCase();
     return text != '0' && text != 'false' && text != 'no';
   }

--- a/lib/src/features/routines/domain/entities/workout_plan.dart
+++ b/lib/src/features/routines/domain/entities/workout_plan.dart
@@ -2,6 +2,12 @@ class WorkoutPlan {
   final int id;
   final String name;
   final String frequency;
+  final bool isActive;
 
-  WorkoutPlan({required this.id, required this.name, required this.frequency});
+  WorkoutPlan({
+    required this.id,
+    required this.name,
+    required this.frequency,
+    this.isActive = true,
+  });
 }

--- a/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
+++ b/lib/src/features/routines/domain/repositories/workout_plan_repository.dart
@@ -24,6 +24,7 @@ abstract class WorkoutPlanRepository {
     String mainMuscleGroup,
   );
   Future<void> createWorkoutPlan(String name, String frequency);
+  Future<void> setWorkoutPlanActive(int planId, bool isActive);
   Future<List<PlanExerciseDetail>> getPlanExerciseDetails(int planId);
 
   Future<void> addExerciseToPlan(

--- a/lib/src/features/routines/domain/usecases/set_workout_plan_active_usecase.dart
+++ b/lib/src/features/routines/domain/usecases/set_workout_plan_active_usecase.dart
@@ -1,0 +1,10 @@
+import '../repositories/workout_plan_repository.dart';
+
+class SetWorkoutPlanActiveUseCase {
+  final WorkoutPlanRepository _repo;
+  const SetWorkoutPlanActiveUseCase(this._repo);
+
+  Future<void> call(int planId, bool isActive) {
+    return _repo.setWorkoutPlanActive(planId, isActive);
+  }
+}

--- a/lib/src/features/routines/presentation/pages/routines_screen.dart
+++ b/lib/src/features/routines/presentation/pages/routines_screen.dart
@@ -4,6 +4,7 @@ import '../../../routines/presentation/providers/workout_plan_provider.dart';
 import '../pages/exercises_screen.dart';
 import '../pages/edit_routine_screen.dart';
 import '../widgets/add_routine_button.dart';
+import '../widgets/deactivated_routines_dropdown.dart';
 
 class RoutinesScreen extends ConsumerWidget {
   static const routeName = '/routines';
@@ -18,36 +19,73 @@ class RoutinesScreen extends ConsumerWidget {
       appBar: AppBar(title: const Text('Rutinas')),
       floatingActionButton: const AddRoutineButton(), // <- el botón mágico
       body: asyncPlans.when(
-        data: (plans) => ListView.builder(
-          itemCount: plans.length,
-          itemBuilder: (_, i) {
-            final plan = plans[i];
-            return ListTile(
-              leading: Text(plan.id.toString()),
-              title: Text(plan.name),
-              subtitle: Text(plan.frequency),
-              trailing: IconButton(
-                icon: const Icon(Icons.edit),
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => EditRoutineScreen(planId: plan.id),
-                    ),
-                  );
-                },
-              ),
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => ExercisesScreen(planId: plan.id),
+        data: (plans) {
+          final activePlans = plans.where((plan) => plan.isActive).toList();
+          final inactivePlans = plans.where((plan) => !plan.isActive).toList();
+          return Column(
+            children: [
+              if (inactivePlans.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                  child: DeactivatedRoutinesDropdown(
+                    plans: inactivePlans,
+                    onActivate: (planId) => ref
+                        .read(workoutPlanProvider.notifier)
+                        .setPlanActive(planId, true),
                   ),
-                );
-              },
-            );
-          },
-        ),
+                ),
+              Expanded(
+                child: activePlans.isEmpty
+                    ? const Center(child: Text('No hay rutinas activas'))
+                    : ListView.builder(
+                        itemCount: activePlans.length,
+                        itemBuilder: (_, i) {
+                          final plan = activePlans[i];
+                          return ListTile(
+                            leading: Text(plan.id.toString()),
+                            title: Text(plan.name),
+                            subtitle: Text(plan.frequency),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  icon: const Icon(Icons.edit),
+                                  onPressed: () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (_) =>
+                                            EditRoutineScreen(planId: plan.id),
+                                      ),
+                                    );
+                                  },
+                                ),
+                                IconButton(
+                                  icon:
+                                      const Icon(Icons.pause_circle_outline),
+                                  tooltip: 'Desactivar rutina',
+                                  onPressed: () => ref
+                                      .read(workoutPlanProvider.notifier)
+                                      .setPlanActive(plan.id, false),
+                                ),
+                              ],
+                            ),
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) =>
+                                      ExercisesScreen(planId: plan.id),
+                                ),
+                              );
+                            },
+                          );
+                        },
+                      ),
+              ),
+            ],
+          );
+        },
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, __) => Center(child: Text('Error: $e')),
       ),

--- a/lib/src/features/routines/presentation/providers/workout_plan_provider.dart
+++ b/lib/src/features/routines/presentation/providers/workout_plan_provider.dart
@@ -1,9 +1,37 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../data/repositories/workout_plan_repository_impl.dart';
+import '../../domain/entities/workout_plan.dart';
 import '../../domain/usecases/get_workout_plans_usecase.dart';
+import '../../domain/usecases/set_workout_plan_active_usecase.dart';
 
-final workoutPlanProvider = FutureProvider.autoDispose((ref) async {
-  final repo = WorkoutPlanRepositoryImpl();
-  final usecase = GetWorkoutPlansUseCase(repo);
-  return usecase();
+final workoutPlanProvider = StateNotifierProvider<WorkoutPlanController,
+    AsyncValue<List<WorkoutPlan>>>((ref) {
+  return WorkoutPlanController(WorkoutPlanRepositoryImpl());
 });
+
+class WorkoutPlanController extends StateNotifier<AsyncValue<List<WorkoutPlan>>> {
+  final GetWorkoutPlansUseCase _getPlans;
+  final SetWorkoutPlanActiveUseCase _setPlanActive;
+
+  WorkoutPlanController(WorkoutPlanRepositoryImpl repo)
+      : _getPlans = GetWorkoutPlansUseCase(repo),
+        _setPlanActive = SetWorkoutPlanActiveUseCase(repo),
+        super(const AsyncLoading()) {
+    _loadPlans();
+  }
+
+  Future<void> _loadPlans() async {
+    try {
+      final plans = await _getPlans();
+      state = AsyncData(plans);
+    } catch (error, stackTrace) {
+      state = AsyncError(error, stackTrace);
+    }
+  }
+
+  Future<void> setPlanActive(int planId, bool isActive) async {
+    state = const AsyncLoading();
+    await _setPlanActive(planId, isActive);
+    await _loadPlans();
+  }
+}

--- a/lib/src/features/routines/presentation/widgets/deactivated_routines_dropdown.dart
+++ b/lib/src/features/routines/presentation/widgets/deactivated_routines_dropdown.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../../domain/entities/workout_plan.dart';
+
+class DeactivatedRoutinesDropdown extends StatefulWidget {
+  final List<WorkoutPlan> plans;
+  final ValueChanged<int> onActivate;
+
+  const DeactivatedRoutinesDropdown({
+    required this.plans,
+    required this.onActivate,
+    super.key,
+  });
+
+  @override
+  State<DeactivatedRoutinesDropdown> createState() =>
+      _DeactivatedRoutinesDropdownState();
+}
+
+class _DeactivatedRoutinesDropdownState
+    extends State<DeactivatedRoutinesDropdown> {
+  int? _selectedPlanId;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.plans.isEmpty) return const SizedBox.shrink();
+
+    return ExpansionTile(
+      title: const Text('Rutinas desactivadas'),
+      subtitle: Text('${widget.plans.length} disponibles'),
+      childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      children: [
+        DropdownButtonFormField<int>(
+          value: _selectedPlanId,
+          decoration: const InputDecoration(
+            labelText: 'Selecciona una rutina para activar',
+            border: OutlineInputBorder(),
+          ),
+          items: widget.plans
+              .map(
+                (plan) => DropdownMenuItem<int>(
+                  value: plan.id,
+                  child: Text(plan.name),
+                ),
+              )
+              .toList(),
+          onChanged: (value) {
+            if (value == null) return;
+            widget.onActivate(value);
+            setState(() => _selectedPlanId = null);
+          },
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a simple soft-delete mechanism so routines can be hidden without removing their data. 
- Allow users to deactivate a routine from the main list and reactivate it later from a compact dropdown. 
- Persist the active state in the workbook schema so existing data remains intact. 

### Description
- Add `isActive` to the `WorkoutPlan` entity and extend the `workout_plan.xlsx` schema with the `is_active` column and sample values. 
- Implement parsing/ensure logic and `setWorkoutPlanActive` persistence in `WorkoutPlanRepositoryImpl` (`_parseActiveCell`, `_ensurePlanActiveColumn`, and `setWorkoutPlanActive`). 
- Introduce `SetWorkoutPlanActiveUseCase` and replace the previous `FutureProvider` with a `StateNotifierProvider` `WorkoutPlanController` that exposes `setPlanActive` and reloads plans. 
- Update the UI by adding `DeactivatedRoutinesDropdown` and changing `RoutinesScreen` to show only active plans, add a deactivate button, and surface inactive plans in the dropdown for reactivation. 

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696299252cb083238429dd217be0fb90)