### PR TITLE
Filter best logs to planned set count

### DIFF
--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -179,7 +179,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                               return asyncLogs.when(
                                 data: (logs) {
                                   final last = _lastLogs(logs);
-                                  final best = _bestLogs(logs);
+                                  final best = _bestLogs(logs, detail.sets);
                                   return ExerciseTile(
                                     key: _keys[detail.exerciseId],
                                     detail: detail,
@@ -337,30 +337,44 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
       ..sort((a, b) => a.setNumber.compareTo(b.setNumber));
   }
 
-  List<WorkoutLogEntry> _bestLogs(List<WorkoutLogEntry> logs) {
+  List<WorkoutLogEntry> _bestLogs(
+    List<WorkoutLogEntry> logs,
+    int plannedSets,
+  ) {
     if (logs.isEmpty) return [];
+    if (plannedSets <= 0) return [];
 
     final grouped = <DateTime, List<WorkoutLogEntry>>{};
     for (final l in logs) {
       grouped.putIfAbsent(l.date, () => []).add(l);
     }
 
+    List<WorkoutLogEntry> normalizedLogs(List<WorkoutLogEntry> ls) {
+      final filtered = ls.where((entry) => entry.setNumber <= plannedSets).toList()
+        ..sort((a, b) => a.setNumber.compareTo(b.setNumber));
+      if (filtered.length < plannedSets) {
+        return [];
+      }
+      return filtered;
+    }
+
     double tonnage(List<WorkoutLogEntry> ls) =>
         ls.fold(0, (sum, e) => sum + e.reps * e.weight);
 
-    DateTime bestDate = grouped.keys.first;
-    double bestTon = tonnage(grouped[bestDate]!);
+    DateTime? bestDate;
+    double bestTon = 0;
     grouped.forEach((date, ls) {
-      final t = tonnage(ls);
-      if (t > bestTon) {
+      final normalized = normalizedLogs(ls);
+      if (normalized.isEmpty) return;
+      final t = tonnage(normalized);
+      if (bestDate == null || t > bestTon) {
         bestTon = t;
         bestDate = date;
       }
     });
 
-    final bestLogs = grouped[bestDate]!;
-    bestLogs.sort((a, b) => a.setNumber.compareTo(b.setNumber));
-    return bestLogs;
+    if (bestDate == null) return [];
+    return normalizedLogs(grouped[bestDate] ?? []);
   }
 
   Future<bool> _confirmExit(BuildContext ctx) async =>

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -344,37 +344,31 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     if (logs.isEmpty) return [];
     if (plannedSets <= 0) return [];
 
-    final grouped = <DateTime, List<WorkoutLogEntry>>{};
-    for (final l in logs) {
-      grouped.putIfAbsent(l.date, () => []).add(l);
+    final grouped = <DateTime, _BestLogSummary>{};
+    for (final entry in logs) {
+      if (entry.setNumber > plannedSets) continue;
+      final summary = grouped.putIfAbsent(entry.date, () => _BestLogSummary());
+      summary.tonnage += entry.reps * entry.weight;
+      summary.logs.add(entry);
     }
-
-    List<WorkoutLogEntry> normalizedLogs(List<WorkoutLogEntry> ls) {
-      final filtered = ls.where((entry) => entry.setNumber <= plannedSets).toList()
-        ..sort((a, b) => a.setNumber.compareTo(b.setNumber));
-      if (filtered.length < plannedSets) {
-        return [];
-      }
-      return filtered;
-    }
-
-    double tonnage(List<WorkoutLogEntry> ls) =>
-        ls.fold(0, (sum, e) => sum + e.reps * e.weight);
 
     DateTime? bestDate;
     double bestTon = 0;
-    grouped.forEach((date, ls) {
-      final normalized = normalizedLogs(ls);
-      if (normalized.isEmpty) return;
-      final t = tonnage(normalized);
-      if (bestDate == null || t > bestTon) {
-        bestTon = t;
+    grouped.forEach((date, summary) {
+      if (summary.logs.length < plannedSets) return;
+      if (bestDate == null || summary.tonnage > bestTon) {
+        bestTon = summary.tonnage;
         bestDate = date;
       }
     });
 
     if (bestDate == null) return [];
-    return normalizedLogs(grouped[bestDate] ?? []);
+    final bestLogs = grouped[bestDate]!.logs
+      ..sort((a, b) => a.setNumber.compareTo(b.setNumber));
+    if (bestLogs.length > plannedSets) {
+      return bestLogs.take(plannedSets).toList();
+    }
+    return bestLogs;
   }
 
   Future<bool> _confirmExit(BuildContext ctx) async =>
@@ -463,4 +457,9 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     }
     return ok ?? false;
   }
+}
+
+class _BestLogSummary {
+  double tonnage = 0;
+  final List<WorkoutLogEntry> logs = [];
 }


### PR DESCRIPTION
### Motivation
- Prevent sessions with extra sets from being chosen as the "best" by ensuring comparisons only consider the planned number of sets.
- Avoid charts and best-log highlights from being skewed by days where more than the planned sets were performed.
- Make best-selection consistent with the exercise `Plan` so the best set is only highlighted when it meets the configured `sets`.

### Description
- Changed `_bestLogs` signature to `_bestLogs(List<WorkoutLogEntry> logs, int plannedSets)` and updated the call site to pass `detail.sets`.
- Added a `normalizedLogs` helper that filters entries to `setNumber <= plannedSets`, sorts them, and returns an empty list if a session has fewer than `plannedSets` entries.
- Compute tonnage only from the normalized logs and select the best date based on that filtered tonnage, returning the normalized logs for the best date or an empty list when none qualify.
- Early-return when `plannedSets <= 0` or when no date meets the planned set count to avoid incorrect best selections.

### Testing
- No automated tests were run for this change.
- No unit tests added or updated as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962e0d5ee4c8323974446366014dbb2)