### PR TITLE
Refine dark theme, rounded navigation, and routines list styling

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -6,19 +6,105 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = const ColorScheme(
+      brightness: Brightness.dark,
+      primary: Color(0xFF8E8CF8),
+      onPrimary: Color(0xFF0F0F10),
+      secondary: Color(0xFF3DD6C6),
+      onSecondary: Color(0xFF0F0F10),
+      error: Color(0xFFFF6B6B),
+      onError: Color(0xFF0F0F10),
+      surface: Color(0xFF1A1A1A),
+      onSurface: Color(0xFFE6E6E6),
+      outline: Color(0xFF323232),
+      shadow: Color(0xFF000000),
+      scrim: Color(0xFF000000),
+      inverseSurface: Color(0xFFE6E6E6),
+      onInverseSurface: Color(0xFF141414),
+      inversePrimary: Color(0xFF5854D6),
+      surfaceTint: Color(0xFF8E8CF8),
+    );
+
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Fit Log',
-      themeMode: ThemeMode.system,
+      themeMode: ThemeMode.dark,
       theme: ThemeData(
         useMaterial3: true,
-        colorSchemeSeed: Colors.blue,
-        brightness: Brightness.light,
-      ),
-      darkTheme: ThemeData(
-        useMaterial3: true,
-        colorSchemeSeed: Colors.blue,
-        brightness: Brightness.dark,
+        colorScheme: colorScheme,
+        scaffoldBackgroundColor: const Color(0xFF141414),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Color(0xFF1B1B1B),
+          surfaceTintColor: Colors.transparent,
+          elevation: 0,
+          centerTitle: true,
+          titleTextStyle: TextStyle(
+            color: Color(0xFFF2F2F2),
+            fontSize: 18,
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.2,
+          ),
+        ),
+        cardTheme: CardTheme(
+          color: const Color(0xFF1E1E1E),
+          elevation: 0,
+          margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(18),
+          ),
+        ),
+        listTileTheme: const ListTileThemeData(
+          contentPadding: EdgeInsets.symmetric(horizontal: 18, vertical: 6),
+          iconColor: Color(0xFF9E9E9E),
+        ),
+        navigationBarTheme: NavigationBarThemeData(
+          backgroundColor: const Color(0xFF1A1A1A),
+          indicatorColor: const Color(0xFF2A2A2A),
+          labelTextStyle: MaterialStateProperty.resolveWith<TextStyle>(
+            (states) => TextStyle(
+              color: states.contains(MaterialState.selected)
+                  ? Colors.white
+                  : const Color(0xFF9A9A9A),
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          iconTheme: MaterialStateProperty.resolveWith<IconThemeData>(
+            (states) => IconThemeData(
+              color: states.contains(MaterialState.selected)
+                  ? Colors.white
+                  : const Color(0xFF8A8A8A),
+            ),
+          ),
+        ),
+        floatingActionButtonTheme: const FloatingActionButtonThemeData(
+          backgroundColor: Color(0xFF8E8CF8),
+          foregroundColor: Color(0xFF0F0F10),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(18)),
+          ),
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          filled: true,
+          fillColor: const Color(0xFF222222),
+          hintStyle: const TextStyle(color: Color(0xFF8A8A8A)),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: const BorderSide(color: Color(0xFF8E8CF8), width: 1.2),
+          ),
+        ),
+        dividerTheme: const DividerThemeData(
+          color: Color(0xFF2E2E2E),
+          thickness: 1,
+          space: 24,
+        ),
       ),
       home: const MainScaffold(),
     );

--- a/lib/src/features/profile/presentation/widgets/add_body_metric_dialog.dart
+++ b/lib/src/features/profile/presentation/widgets/add_body_metric_dialog.dart
@@ -76,8 +76,15 @@ class _AddBodyMetricDialogState extends State<AddBodyMetricDialog> {
   @override
   Widget build(BuildContext context) {
     final last = widget.last;
+    final colorScheme = Theme.of(context).colorScheme;
     return AlertDialog(
-      title: const Text('Registrar métricas'),
+      title: Row(
+        children: [
+          Icon(Icons.monitor_heart, size: 20, color: colorScheme.secondary),
+          const SizedBox(width: 8),
+          const Text('Registrar métricas'),
+        ],
+      ),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -103,11 +110,12 @@ class _AddBodyMetricDialogState extends State<AddBodyMetricDialog> {
         ),
       ),
       actions: [
-        TextButton(
+        TextButton.icon(
           onPressed: () => Navigator.pop(context),
-          child: const Text('Cancelar'),
+          icon: const Icon(Icons.close),
+          label: const Text('Cancelar'),
         ),
-        ElevatedButton(
+        ElevatedButton.icon(
           onPressed: () {
             final last = widget.last;
             final metric = BodyMetric(
@@ -129,7 +137,8 @@ class _AddBodyMetricDialogState extends State<AddBodyMetricDialog> {
             );
             Navigator.pop(context, metric);
           },
-          child: const Text('Guardar'),
+          icon: const Icon(Icons.check),
+          label: const Text('Guardar'),
         ),
       ],
     );

--- a/lib/src/features/profile/presentation/widgets/edit_profile_dialog.dart
+++ b/lib/src/features/profile/presentation/widgets/edit_profile_dialog.dart
@@ -86,8 +86,15 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return AlertDialog(
-      title: const Text('Editar perfil'),
+      title: Row(
+        children: [
+          Icon(Icons.person, size: 20, color: colorScheme.primary),
+          const SizedBox(width: 8),
+          const Text('Editar perfil'),
+        ],
+      ),
       content: SingleChildScrollView(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -115,11 +122,12 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
         ),
       ),
       actions: [
-        TextButton(
+        TextButton.icon(
           onPressed: () => Navigator.pop(context),
-          child: const Text('Cancelar'),
+          icon: const Icon(Icons.close),
+          label: const Text('Cancelar'),
         ),
-        ElevatedButton(
+        ElevatedButton.icon(
           onPressed: () {
             final p = UserProfile(
               id: widget.user.id,
@@ -144,7 +152,8 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
             );
             Navigator.pop(context, p);
           },
-          child: const Text('Guardar'),
+          icon: const Icon(Icons.check),
+          label: const Text('Guardar'),
         ),
       ],
     );

--- a/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
@@ -227,6 +227,7 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
             return const Center(child: Text('Sin ejercicios'));
           }
           return ListView.builder(
+            padding: const EdgeInsets.only(bottom: 96),
             itemCount: details.length,
             itemBuilder: (_, i) {
               final d = details[i];

--- a/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/edit_routine_screen.dart
@@ -60,23 +60,31 @@ class _EditRoutineScreenState extends ConsumerState<EditRoutineScreen> {
       final index = await showDialog<int>(
         context: context,
         builder: (_) => AlertDialog(
-          title: const Text('Posición del ejercicio'),
+          title: Row(
+            children: const [
+              Icon(Icons.format_list_numbered, size: 20),
+              SizedBox(width: 8),
+              Text('Posición del ejercicio'),
+            ],
+          ),
           content: TextField(
             controller: posCtl,
             keyboardType: TextInputType.number,
             decoration: const InputDecoration(labelText: '1 = inicio'),
           ),
           actions: [
-            TextButton(
+            TextButton.icon(
               onPressed: () => Navigator.pop(context),
-              child: const Text('Cancelar'),
+              icon: const Icon(Icons.close),
+              label: const Text('Cancelar'),
             ),
-            TextButton(
+            TextButton.icon(
               onPressed: () => Navigator.pop(
                 context,
                 int.tryParse(posCtl.text) ?? current.length + 1,
               ),
-              child: const Text('OK'),
+              icon: const Icon(Icons.check),
+              label: const Text('OK'),
             ),
           ],
         ),

--- a/lib/src/features/routines/presentation/pages/exercises_screen.dart
+++ b/lib/src/features/routines/presentation/pages/exercises_screen.dart
@@ -96,16 +96,19 @@ class _ExercisesScreenState extends ConsumerState<ExercisesScreen> {
                       final exercise = filtered[i];
                       return Card(
                         child: ListTile(
-                          leading: CircleAvatar(
-                            backgroundColor: colorScheme.primary,
-                            child: Text(
-                              exercise.name.isNotEmpty
-                                  ? exercise.name.characters.first
-                                  : 'E',
-                              style: const TextStyle(
-                                color: Color(0xFF0F0F10),
-                                fontWeight: FontWeight.w700,
+                          leading: Container(
+                            height: 44,
+                            width: 44,
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF2A2A2A),
+                              borderRadius: BorderRadius.circular(14),
+                              border: Border.all(
+                                color: const Color(0xFF3A3A3A),
                               ),
+                            ),
+                            child: Icon(
+                              Icons.sports_gymnastics,
+                              color: colorScheme.primary,
                             ),
                           ),
                           title: Text(exercise.name),

--- a/lib/src/features/routines/presentation/pages/exercises_screen.dart
+++ b/lib/src/features/routines/presentation/pages/exercises_screen.dart
@@ -1,51 +1,146 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/exercises_provider.dart';
+import 'edit_routine_screen.dart';
 import 'start_routine_screen.dart';
 
-class ExercisesScreen extends ConsumerWidget {
+class ExercisesScreen extends ConsumerStatefulWidget {
   final int planId;
   const ExercisesScreen({required this.planId, super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final asyncExercises = ref.watch(exercisesForPlanProvider(planId));
+  ConsumerState<ExercisesScreen> createState() => _ExercisesScreenState();
+}
+
+class _ExercisesScreenState extends ConsumerState<ExercisesScreen> {
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final asyncExercises =
+        ref.watch(exercisesForPlanProvider(widget.planId));
+    final colorScheme = Theme.of(context).colorScheme;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Ejercicios')),
+      appBar: AppBar(
+        title: const Text('Ejercicios'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.tune),
+            tooltip: 'Editar rutina',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => EditRoutineScreen(planId: widget.planId),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
       body: asyncExercises.when(
-        data: (exercises) => ListView.builder(
-          itemCount: exercises.length,
-          itemBuilder: (_, i) {
-            final exercise = exercises[i];
-            return ListTile(
-              title: Text(exercise.name),
-              subtitle: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (exercise.description.isNotEmpty)
-                    Text(
-                      exercise.description,
-                      style: const TextStyle(fontSize: 12),
-                    ),
-                  Text(
-                    '${exercise.category} • ${exercise.mainMuscleGroup}',
-                    style: const TextStyle(fontSize: 11),
+        data: (exercises) {
+          final query = _searchController.text.trim().toLowerCase();
+          final filtered = query.isEmpty
+              ? exercises
+              : exercises
+                  .where((exercise) =>
+                      exercise.name.toLowerCase().contains(query))
+                  .toList();
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                child: TextField(
+                  controller: _searchController,
+                  onChanged: (_) => setState(() {}),
+                  decoration: InputDecoration(
+                    prefixIcon: const Icon(Icons.search),
+                    hintText: 'Buscar ejercicio',
+                    suffixIcon: query.isEmpty
+                        ? null
+                        : IconButton(
+                            icon: const Icon(Icons.close),
+                            onPressed: () {
+                              _searchController.clear();
+                              setState(() {});
+                            },
+                          ),
                   ),
-                ],
+                ),
               ),
-            );
-          },
-        ),
+              if (filtered.isEmpty)
+                Expanded(
+                  child: Center(
+                    child: Text(
+                      query.isEmpty
+                          ? 'Aún no tienes ejercicios'
+                          : 'No hay ejercicios para esa búsqueda',
+                      style: TextStyle(color: colorScheme.onSurface),
+                    ),
+                  ),
+                )
+              else
+                Expanded(
+                  child: ListView.builder(
+                    padding: const EdgeInsets.only(bottom: 90),
+                    itemCount: filtered.length,
+                    itemBuilder: (_, i) {
+                      final exercise = filtered[i];
+                      return Card(
+                        child: ListTile(
+                          leading: CircleAvatar(
+                            backgroundColor: colorScheme.primary,
+                            child: Text(
+                              exercise.name.isNotEmpty
+                                  ? exercise.name.characters.first
+                                  : 'E',
+                              style: const TextStyle(
+                                color: Color(0xFF0F0F10),
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                          title: Text(exercise.name),
+                          subtitle: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              if (exercise.description.isNotEmpty)
+                                Text(
+                                  exercise.description,
+                                  style: const TextStyle(fontSize: 12),
+                                ),
+                              Text(
+                                '${exercise.category} • ${exercise.mainMuscleGroup}',
+                                style: const TextStyle(fontSize: 11),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+            ],
+          );
+        },
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, __) => Center(child: Text('Error: $e')),
       ),
-      floatingActionButton: FloatingActionButton(
-        child: const Icon(Icons.play_arrow),
+      floatingActionButton: FloatingActionButton.extended(
+        icon: const Icon(Icons.play_arrow),
+        label: const Text('Iniciar rutina'),
         onPressed: () => Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) => StartRoutineScreen(planId: planId),
+            builder: (_) => StartRoutineScreen(planId: widget.planId),
           ),
         ),
       ),

--- a/lib/src/features/routines/presentation/pages/routines_screen.dart
+++ b/lib/src/features/routines/presentation/pages/routines_screen.dart
@@ -73,17 +73,19 @@ class RoutinesScreen extends ConsumerWidget {
                           final plan = activePlans[i];
                           return Card(
                             child: ListTile(
-                              leading: CircleAvatar(
-                                backgroundColor:
-                                    Theme.of(context).colorScheme.primary,
-                                child: Text(
-                                  plan.name.isNotEmpty
-                                      ? plan.name.characters.first
-                                      : 'R',
-                                  style: const TextStyle(
-                                    color: Color(0xFF0F0F10),
-                                    fontWeight: FontWeight.w700,
+                              leading: Container(
+                                height: 44,
+                                width: 44,
+                                decoration: BoxDecoration(
+                                  color: const Color(0xFF2A2A2A),
+                                  borderRadius: BorderRadius.circular(14),
+                                  border: Border.all(
+                                    color: const Color(0xFF3A3A3A),
                                   ),
+                                ),
+                                child: const Icon(
+                                  Icons.fitness_center,
+                                  color: Color(0xFF8E8CF8),
                                 ),
                               ),
                               title: Text(plan.name),

--- a/lib/src/features/routines/presentation/pages/routines_screen.dart
+++ b/lib/src/features/routines/presentation/pages/routines_screen.dart
@@ -34,6 +34,35 @@ class RoutinesScreen extends ConsumerWidget {
                         .setPlanActive(planId, true),
                   ),
                 ),
+              if (activePlans.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.bolt, size: 18, color: Color(0xFF8E8CF8)),
+                      const SizedBox(width: 8),
+                      const Text(
+                        'Rutinas activas',
+                        style: TextStyle(fontWeight: FontWeight.w600),
+                      ),
+                      const Spacer(),
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 4,
+                        ),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF2A2A2A),
+                          borderRadius: BorderRadius.circular(999),
+                        ),
+                        child: Text(
+                          '${activePlans.length}',
+                          style: const TextStyle(fontSize: 12),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               Expanded(
                 child: activePlans.isEmpty
                     ? const Center(child: Text('No hay rutinas activas'))

--- a/lib/src/features/routines/presentation/pages/routines_screen.dart
+++ b/lib/src/features/routines/presentation/pages/routines_screen.dart
@@ -41,44 +41,60 @@ class RoutinesScreen extends ConsumerWidget {
                         itemCount: activePlans.length,
                         itemBuilder: (_, i) {
                           final plan = activePlans[i];
-                          return ListTile(
-                            leading: Text(plan.id.toString()),
-                            title: Text(plan.name),
-                            subtitle: Text(plan.frequency),
-                            trailing: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                IconButton(
-                                  icon: const Icon(Icons.edit),
-                                  onPressed: () {
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (_) =>
-                                            EditRoutineScreen(planId: plan.id),
-                                      ),
-                                    );
-                                  },
+                          return Card(
+                            child: ListTile(
+                              leading: CircleAvatar(
+                                backgroundColor:
+                                    Theme.of(context).colorScheme.primary,
+                                child: Text(
+                                  plan.name.isNotEmpty
+                                      ? plan.name.characters.first
+                                      : 'R',
+                                  style: const TextStyle(
+                                    color: Color(0xFF0F0F10),
+                                    fontWeight: FontWeight.w700,
+                                  ),
                                 ),
-                                IconButton(
-                                  icon:
-                                      const Icon(Icons.pause_circle_outline),
-                                  tooltip: 'Desactivar rutina',
-                                  onPressed: () => ref
-                                      .read(workoutPlanProvider.notifier)
-                                      .setPlanActive(plan.id, false),
-                                ),
-                              ],
+                              ),
+                              title: Text(plan.name),
+                              subtitle: Text(plan.frequency),
+                              trailing: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  IconButton(
+                                    icon: const Icon(Icons.edit_outlined),
+                                    onPressed: () {
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (_) => EditRoutineScreen(
+                                            planId: plan.id,
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                  IconButton(
+                                    icon: const Icon(
+                                      Icons.pause_circle_outline,
+                                    ),
+                                    tooltip: 'Desactivar rutina',
+                                    onPressed: () => ref
+                                        .read(workoutPlanProvider.notifier)
+                                        .setPlanActive(plan.id, false),
+                                  ),
+                                ],
+                              ),
+                              onTap: () {
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) =>
+                                        ExercisesScreen(planId: plan.id),
+                                  ),
+                                );
+                              },
                             ),
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (_) =>
-                                      ExercisesScreen(planId: plan.id),
-                                ),
-                              );
-                            },
                           );
                         },
                       ),

--- a/lib/src/features/routines/presentation/pages/routines_screen.dart
+++ b/lib/src/features/routines/presentation/pages/routines_screen.dart
@@ -67,6 +67,7 @@ class RoutinesScreen extends ConsumerWidget {
                 child: activePlans.isEmpty
                     ? const Center(child: Text('No hay rutinas activas'))
                     : ListView.builder(
+                        padding: const EdgeInsets.only(bottom: 96),
                         itemCount: activePlans.length,
                         itemBuilder: (_, i) {
                           final plan = activePlans[i];

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -181,11 +181,17 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                 bool isComplete(PlanExerciseDetail detail) =>
                     _keys[detail.exerciseId]?.currentState?.isComplete(logsMap) ??
                     false;
+                bool isExpanded(PlanExerciseDetail detail) =>
+                    _expandedExerciseId == detail.exerciseId;
+                bool isArchivedComplete(PlanExerciseDetail detail) =>
+                    isComplete(detail) && !isExpanded(detail);
                 final done = entries.where((entry) => isComplete(entry.value)).length;
-                final pendingEntries =
-                    entries.where((entry) => !isComplete(entry.value)).toList();
-                final completedEntries =
-                    entries.where((entry) => isComplete(entry.value)).toList();
+                final pendingEntries = entries
+                    .where((entry) => !isArchivedComplete(entry.value))
+                    .toList();
+                final completedEntries = entries
+                    .where((entry) => isArchivedComplete(entry.value))
+                    .toList();
                 return Column(
                   children: [
                     Padding(

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -48,6 +48,13 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     super.initState();
     ref.read(workoutLogProvider.notifier).startSession();
     _ticker = Timer.periodic(const Duration(seconds: 1), (_) => setState(() {}));
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Sesión iniciada')),
+        );
+      }
+    });
   }
 
   @override
@@ -67,7 +74,14 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     return WillPopScope(
       onWillPop: () async {
         final exit = await showConfirmExitSheet(context);
-        if (exit) notifier.clear();
+        if (exit) {
+          notifier.clear();
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Sesión cancelada')),
+            );
+          }
+        }
         return exit;
       },
       child: Scaffold(
@@ -81,13 +95,27 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
               final exit = await showConfirmExitSheet(context);
               if (exit) {
                 notifier.clear();
+                if (mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Sesión cancelada')),
+                  );
+                }
                 if (mounted) Navigator.pop(context);
               }
             },
           ),
-          title: Text(
-            WorkoutSessionHelper.formatDuration(notifier.sessionDuration),
-            style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+          title: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 250),
+            child: Text(
+              WorkoutSessionHelper.formatDuration(notifier.sessionDuration),
+              key: ValueKey<String>(
+                WorkoutSessionHelper.formatDuration(notifier.sessionDuration),
+              ),
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
           ),
           centerTitle: true,
           actions: [
@@ -127,6 +155,11 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                 _mood = result.mood;
                 _notesCtl.text = result.notes;
                 notifier.clear();
+                if (mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Sesión finalizada')),
+                  );
+                }
                 if (mounted) Navigator.pop(context);
               },
             ),

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -12,7 +12,6 @@ import '../../domain/usecases/save_workout_logs_usecase.dart';
 import '../../domain/usecases/save_workout_session_usecase.dart';
 import '../widgets/exercise_tile.dart';
 import '../widgets/finish_session_dialog.dart';
-import '../widgets/progress_header.dart';
 import '../widgets/confirm_exit_sheet.dart';
 import '../widgets/session_summary_card.dart';
 import '../../../history/presentation/providers/history_providers.dart';
@@ -104,19 +103,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
               }
             },
           ),
-          title: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 250),
-            child: Text(
-              WorkoutSessionHelper.formatDuration(notifier.sessionDuration),
-              key: ValueKey<String>(
-                WorkoutSessionHelper.formatDuration(notifier.sessionDuration),
-              ),
-              style: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
+          title: const Text('Sesión activa'),
           centerTitle: true,
           actions: [
             IconButton(
@@ -195,7 +182,6 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                 ).length;
                 return Column(
                   children: [
-                    ProgressHeader(completed: done, total: list.length),
                     Padding(
                       padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
                       child: SessionSummaryCard(

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -181,17 +181,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                 bool isComplete(PlanExerciseDetail detail) =>
                     _keys[detail.exerciseId]?.currentState?.isComplete(logsMap) ??
                     false;
-                bool isExpanded(PlanExerciseDetail detail) =>
-                    _expandedExerciseId == detail.exerciseId;
-                bool isArchivedComplete(PlanExerciseDetail detail) =>
-                    isComplete(detail) && !isExpanded(detail);
                 final done = entries.where((entry) => isComplete(entry.value)).length;
-                final pendingEntries = entries
-                    .where((entry) => !isArchivedComplete(entry.value))
-                    .toList();
-                final completedEntries = entries
-                    .where((entry) => isArchivedComplete(entry.value))
-                    .toList();
                 return Column(
                   children: [
                     Padding(
@@ -209,7 +199,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                       child: ListView(
                         padding: const EdgeInsets.fromLTRB(12, 16, 12, 80),
                         children: [
-                          for (final entry in pendingEntries)
+                          for (final entry in entries)
                             SessionExerciseTile(
                               detail: entry.value,
                               index: entry.key,
@@ -229,48 +219,6 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                               planId: widget.planId,
                               showBest: _showBest,
                               onSwap: () => swapExercise(entry.key),
-                            ),
-                          if (completedEntries.isNotEmpty)
-                            Padding(
-                              padding: const EdgeInsets.only(top: 8),
-                              child: Theme(
-                                data: Theme.of(context).copyWith(
-                                  dividerColor: Colors.transparent,
-                                ),
-                                child: ExpansionTile(
-                                  tilePadding:
-                                      const EdgeInsets.symmetric(horizontal: 4),
-                                  title: Text(
-                                    'Completados (${completedEntries.length})',
-                                    style: const TextStyle(
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                  children: [
-                                    for (final entry in completedEntries)
-                                      SessionExerciseTile(
-                                        detail: entry.value,
-                                        index: entry.key,
-                                        expandedExerciseId: _expandedExerciseId,
-                                        onToggle: (exerciseId) => setState(() {
-                                          _expandedExerciseId =
-                                              _expandedExerciseId == exerciseId
-                                                  ? null
-                                                  : exerciseId;
-                                        }),
-                                        keys: _keys,
-                                        logsMap: logsMap,
-                                        highlightDone: isComplete(entry.value),
-                                        onChanged: () => setState(() {}),
-                                        removeLog: notifier.remove,
-                                        updateLog: notifier.update,
-                                        planId: widget.planId,
-                                        showBest: _showBest,
-                                        onSwap: () => swapExercise(entry.key),
-                                      ),
-                                  ],
-                                ),
-                              ),
                             ),
                         ],
                       ),

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -1,7 +1,3 @@
-// lib/src/features/routines/presentation/pages/start_routine_screen.dart
-//
-// Neutral-toned, shadow-light redesign with fixed compile errors.
-
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -18,6 +14,7 @@ import '../widgets/exercise_tile.dart';
 import '../widgets/finish_session_dialog.dart';
 import '../widgets/progress_header.dart';
 import '../widgets/confirm_exit_sheet.dart';
+import '../widgets/session_summary_card.dart';
 import '../../../history/presentation/providers/history_providers.dart';
 import '../providers/exercises_provider.dart';
 import 'select_exercise_screen.dart';
@@ -95,10 +92,6 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
           centerTitle: true,
           actions: [
             IconButton(
-              icon: Icon(_showBest ? Icons.star : Icons.star_border),
-              onPressed: () => setState(() => _showBest = !_showBest),
-            ),
-            IconButton(
               icon: const Icon(Icons.add),
               onPressed: addExercise,
             ),
@@ -170,9 +163,20 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                 return Column(
                   children: [
                     ProgressHeader(completed: done, total: list.length),
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                      child: SessionSummaryCard(
+                        duration: WorkoutSessionHelper.formatDuration(
+                          notifier.sessionDuration,
+                        ),
+                        completion: '$done/${list.length}',
+                        showBest: _showBest,
+                        onToggleBest: () => setState(() => _showBest = !_showBest),
+                      ),
+                    ),
                     Expanded(
                       child: ListView(
-                        padding: const EdgeInsets.fromLTRB(12, 100, 12, 80),
+                        padding: const EdgeInsets.fromLTRB(12, 16, 12, 80),
                         children: [
                           for (var entry in list.asMap().entries)
                             Consumer(builder: (context, ref, _) {
@@ -259,5 +263,4 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     );
   }
 
- 
 }

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -14,7 +14,7 @@ import '../widgets/exercise_tile.dart';
 import '../widgets/finish_session_dialog.dart';
 import '../widgets/confirm_exit_sheet.dart';
 import '../widgets/session_summary_card.dart';
-import '../../../history/presentation/providers/history_providers.dart';
+import '../widgets/session_exercise_tile.dart';
 import '../providers/exercises_provider.dart';
 import 'select_exercise_screen.dart';
 import '../../services/workout_session_helper.dart';
@@ -177,9 +177,15 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
               data: (dets) {
                 _sessionDetails ??= List.of(dets);
                 final list = _sessionDetails!;
-                final done = list.where((d) =>
-                  _keys[d.exerciseId]?.currentState?.isComplete(logsMap) ?? false
-                ).length;
+                final entries = list.asMap().entries.toList();
+                bool isComplete(PlanExerciseDetail detail) =>
+                    _keys[detail.exerciseId]?.currentState?.isComplete(logsMap) ??
+                    false;
+                final done = entries.where((entry) => isComplete(entry.value)).length;
+                final pendingEntries =
+                    entries.where((entry) => !isComplete(entry.value)).toList();
+                final completedEntries =
+                    entries.where((entry) => isComplete(entry.value)).toList();
                 return Column(
                   children: [
                     Padding(
@@ -197,78 +203,69 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                       child: ListView(
                         padding: const EdgeInsets.fromLTRB(12, 16, 12, 80),
                         children: [
-                          for (var entry in list.asMap().entries)
-                            Consumer(builder: (context, ref, _) {
-                              final detail = entry.value;
-                              final idx = entry.key;
-                              _keys[detail.exerciseId] ??= GlobalKey<ExerciseTileState>();
-                              final doneEx = _keys[detail.exerciseId]
-                                      ?.currentState
-                                      ?.isComplete(logsMap) ?? false;
-                              final asyncLogs = ref.watch(logsByExerciseProvider(detail.exerciseId));
-                              return asyncLogs.when(
-                                data: (logs) {
-                                  final last = WorkoutSessionHelper.lastLogs(logs);
-                                  final best = WorkoutSessionHelper.bestLogs(logs);
-                                  return ExerciseTile(
-                                    key: _keys[detail.exerciseId],
-                                    detail: detail,
-                                    expanded: _expandedExerciseId == detail.exerciseId,
-                                    onToggle: () => setState(() {
-                                      _expandedExerciseId = _expandedExerciseId == detail.exerciseId
-                                          ? null
-                                          : detail.exerciseId;
-                                    }),
-                                    logsMap: logsMap,
-                                    highlightDone: doneEx,
-                                    onChanged: () => setState(() {}),
-                                    removeLog: notifier.remove,
-                                    update: notifier.update,
-                                    planId: widget.planId,
-                                    lastLogs: last,
-                                    bestLogs: best,
-                                    showBest: _showBest,
-                                    onSwap: () => swapExercise(idx),
-                                  );
-                                },
-                                loading: () => ExerciseTile(
-                                  key: _keys[detail.exerciseId],
-                                  detail: detail,
-                                  expanded: _expandedExerciseId == detail.exerciseId,
-                                  onToggle: () => setState(() {
-                                    _expandedExerciseId = _expandedExerciseId == detail.exerciseId
+                          for (final entry in pendingEntries)
+                            SessionExerciseTile(
+                              detail: entry.value,
+                              index: entry.key,
+                              expandedExerciseId: _expandedExerciseId,
+                              onToggle: (exerciseId) => setState(() {
+                                _expandedExerciseId =
+                                    _expandedExerciseId == exerciseId
                                         ? null
-                                        : detail.exerciseId;
-                                  }),
-                                  logsMap: logsMap,
-                                  highlightDone: doneEx,
-                                  onChanged: () => setState(() {}),
-                                  removeLog: notifier.remove,
-                                  update: notifier.update,
-                                  planId: widget.planId,
-                                  showBest: _showBest,
-                                  onSwap: () => swapExercise(idx),
+                                        : exerciseId;
+                              }),
+                              keys: _keys,
+                              logsMap: logsMap,
+                              highlightDone: isComplete(entry.value),
+                              onChanged: () => setState(() {}),
+                              removeLog: notifier.remove,
+                              updateLog: notifier.update,
+                              planId: widget.planId,
+                              showBest: _showBest,
+                              onSwap: () => swapExercise(entry.key),
+                            ),
+                          if (completedEntries.isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: Theme(
+                                data: Theme.of(context).copyWith(
+                                  dividerColor: Colors.transparent,
                                 ),
-                                error: (e, _) => ExerciseTile(
-                                  key: _keys[detail.exerciseId],
-                                  detail: detail,
-                                  expanded: _expandedExerciseId == detail.exerciseId,
-                                  onToggle: () => setState(() {
-                                    _expandedExerciseId = _expandedExerciseId == detail.exerciseId
-                                        ? null
-                                        : detail.exerciseId;
-                                  }),
-                                  logsMap: logsMap,
-                                  highlightDone: doneEx,
-                                  onChanged: () => setState(() {}),
-                                  removeLog: notifier.remove,
-                                  update: notifier.update,
-                                  planId: widget.planId,
-                                  showBest: _showBest,
-                                  onSwap: () => swapExercise(idx),
+                                child: ExpansionTile(
+                                  tilePadding:
+                                      const EdgeInsets.symmetric(horizontal: 4),
+                                  title: Text(
+                                    'Completados (${completedEntries.length})',
+                                    style: const TextStyle(
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                  children: [
+                                    for (final entry in completedEntries)
+                                      SessionExerciseTile(
+                                        detail: entry.value,
+                                        index: entry.key,
+                                        expandedExerciseId: _expandedExerciseId,
+                                        onToggle: (exerciseId) => setState(() {
+                                          _expandedExerciseId =
+                                              _expandedExerciseId == exerciseId
+                                                  ? null
+                                                  : exerciseId;
+                                        }),
+                                        keys: _keys,
+                                        logsMap: logsMap,
+                                        highlightDone: isComplete(entry.value),
+                                        onChanged: () => setState(() {}),
+                                        removeLog: notifier.remove,
+                                        updateLog: notifier.update,
+                                        planId: widget.planId,
+                                        showBest: _showBest,
+                                        onSwap: () => swapExercise(entry.key),
+                                      ),
+                                  ],
                                 ),
-                              );
-                            }),
+                              ),
+                            ),
                         ],
                       ),
                     ),

--- a/lib/src/features/routines/presentation/widgets/add_routine_button.dart
+++ b/lib/src/features/routines/presentation/widgets/add_routine_button.dart
@@ -17,7 +17,13 @@ class AddRoutineButton extends ConsumerWidget {
         await showDialog(
           context: context,
           builder: (_) => AlertDialog(
-            title: const Text('Nueva Rutina'),
+            title: Row(
+              children: const [
+                Icon(Icons.playlist_add, size: 20),
+                SizedBox(width: 8),
+                Text('Nueva Rutina'),
+              ],
+            ),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -32,11 +38,12 @@ class AddRoutineButton extends ConsumerWidget {
               ],
             ),
             actions: [
-              TextButton(
+              TextButton.icon(
                 onPressed: () => Navigator.pop(context),
-                child: const Text('Cancelar'),
+                icon: const Icon(Icons.close),
+                label: const Text('Cancelar'),
               ),
-              ElevatedButton(
+              ElevatedButton.icon(
                 onPressed: () async {
                   final repo = WorkoutPlanRepositoryImpl();
                   final usecase = CreateWorkoutPlanUseCase(repo);
@@ -47,7 +54,8 @@ class AddRoutineButton extends ConsumerWidget {
                   ref.invalidate(workoutPlanProvider); // Refrescar lista
                   Navigator.pop(context);
                 },
-                child: const Text('Guardar'),
+                icon: const Icon(Icons.check),
+                label: const Text('Guardar'),
               ),
             ],
           ),

--- a/lib/src/features/routines/presentation/widgets/add_routine_button.dart
+++ b/lib/src/features/routines/presentation/widgets/add_routine_button.dart
@@ -24,6 +24,7 @@ class AddRoutineButton extends ConsumerWidget {
                 Text('Nueva Rutina'),
               ],
             ),
+            contentPadding: const EdgeInsets.fromLTRB(24, 12, 24, 8),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -31,12 +32,14 @@ class AddRoutineButton extends ConsumerWidget {
                   controller: nameController,
                   decoration: const InputDecoration(labelText: 'Nombre de rutina'),
                 ),
+                const SizedBox(height: 12),
                 TextField(
                   controller: frequencyController,
                   decoration: const InputDecoration(labelText: 'Frecuencia'),
                 ),
               ],
             ),
+            actionsPadding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
             actions: [
               TextButton.icon(
                 onPressed: () => Navigator.pop(context),

--- a/lib/src/features/routines/presentation/widgets/confirm_exit_sheet.dart
+++ b/lib/src/features/routines/presentation/widgets/confirm_exit_sheet.dart
@@ -10,9 +10,11 @@ Future<bool> showConfirmExitSheet(BuildContext context) async =>
       builder: (_) => Padding(
         padding: const EdgeInsets.all(24),
         child: Column(mainAxisSize: MainAxisSize.min, children: [
+          const Icon(Icons.warning_amber_rounded, color: Colors.amber, size: 28),
+          const SizedBox(height: 8),
           const Text(
             '¿Salir sin guardar?',
-            style: TextStyle(fontWeight: FontWeight.w600, color: Colors.white38),
+            style: TextStyle(fontWeight: FontWeight.w600, color: Colors.white),
           ),
           const SizedBox(height: 8),
           const Text(
@@ -22,17 +24,19 @@ Future<bool> showConfirmExitSheet(BuildContext context) async =>
           const SizedBox(height: 20),
           Row(children: [
             Expanded(
-              child: OutlinedButton(
+              child: OutlinedButton.icon(
                 onPressed: () => Navigator.pop(context, false),
-                child: const Text('Cancelar'),
+                icon: const Icon(Icons.close),
+                label: const Text('Cancelar'),
               ),
             ),
             const SizedBox(width: 12),
             Expanded(
-              child: ElevatedButton(
+              child: ElevatedButton.icon(
                 style: ElevatedButton.styleFrom(backgroundColor: Colors.redAccent),
                 onPressed: () => Navigator.pop(context, true),
-                child: const Text('Salir'),
+                icon: const Icon(Icons.exit_to_app),
+                label: const Text('Salir'),
               ),
             ),
           ]),

--- a/lib/src/features/routines/presentation/widgets/exercise_json_dialog.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_json_dialog.dart
@@ -13,9 +13,16 @@ class ExerciseJsonDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final jsonCtl = TextEditingController(text: initialJson);
+    final colorScheme = Theme.of(context).colorScheme;
 
     return AlertDialog(
-      title: Text(title),
+      title: Row(
+        children: [
+          Icon(Icons.code, size: 20, color: colorScheme.primary),
+          const SizedBox(width: 8),
+          Text(title),
+        ],
+      ),
       content: TextField(
         controller: jsonCtl,
         maxLines: 10,
@@ -26,13 +33,15 @@ class ExerciseJsonDialog extends StatelessWidget {
         ),
       ),
       actions: [
-        TextButton(
+        TextButton.icon(
           onPressed: () => Navigator.pop(context),
-          child: const Text('Cancelar'),
+          icon: const Icon(Icons.close),
+          label: const Text('Cancelar'),
         ),
-        ElevatedButton(
+        ElevatedButton.icon(
           onPressed: () => Navigator.pop(context, jsonCtl.text),
-          child: const Text('Guardar'),
+          icon: const Icon(Icons.check),
+          label: const Text('Guardar'),
         ),
       ],
     );

--- a/lib/src/features/routines/presentation/widgets/exercise_tile.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_tile.dart
@@ -233,6 +233,12 @@ class ExerciseTileState extends State<ExerciseTile>
                   _persist(idx);
                   widget.onChanged();
                 },
+                onTap: () {
+                  c.selection = TextSelection(
+                    baseOffset: 0,
+                    extentOffset: c.text.length,
+                  );
+                },
                 textAlign: TextAlign.center,
                 style: TextStyle(
                     fontSize: 13,

--- a/lib/src/features/routines/presentation/widgets/exercise_tile.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_tile.dart
@@ -490,10 +490,16 @@ class ExerciseTileState extends State<ExerciseTile>
                             const SizedBox(width: 8),
                             _rirBadge(_rirCtl[i]),
                             const Spacer(),
-                            Icon(
-                              done ? Icons.check_circle : Icons.circle,
-                              size: 18,
-                              color: done ? Colors.green : Colors.grey,
+                            AnimatedSwitcher(
+                              duration: const Duration(milliseconds: 250),
+                              transitionBuilder: (child, animation) =>
+                                  ScaleTransition(scale: animation, child: child),
+                              child: Icon(
+                                done ? Icons.check_circle : Icons.circle,
+                                key: ValueKey<bool>(done),
+                                size: 18,
+                                color: done ? Colors.green : Colors.grey,
+                              ),
                             ),
                           ],
                         ),

--- a/lib/src/features/routines/presentation/widgets/finish_session_dialog.dart
+++ b/lib/src/features/routines/presentation/widgets/finish_session_dialog.dart
@@ -74,11 +74,18 @@ class _FinishSessionDialogState extends State<FinishSessionDialog> {
   @override
   Widget build(BuildContext context) {
     final canFinish = _energy != null && _mood != null;
+    final colorScheme = Theme.of(context).colorScheme;
 
     return AlertDialog(
       backgroundColor: const Color(0xFF1F1F1F),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-      title: const Text('Finalizar sesión'),
+      title: Row(
+        children: [
+          Icon(Icons.flag_circle, size: 20, color: colorScheme.primary),
+          const SizedBox(width: 8),
+          const Text('Finalizar sesión'),
+        ],
+      ),
       titleTextStyle: const TextStyle(
         fontSize: 18,
         fontWeight: FontWeight.w600,
@@ -121,11 +128,12 @@ class _FinishSessionDialogState extends State<FinishSessionDialog> {
         ),
       ),
       actions: [
-        TextButton(
+        TextButton.icon(
           onPressed: () => Navigator.of(context).pop(null),
-          child: const Text('Cancelar'),
+          icon: const Icon(Icons.close),
+          label: const Text('Cancelar'),
         ),
-        ElevatedButton(
+        ElevatedButton.icon(
           onPressed: canFinish
               ? () => Navigator.of(context).pop((
                     energy: _energy!,
@@ -133,7 +141,8 @@ class _FinishSessionDialogState extends State<FinishSessionDialog> {
                     notes: _notesCtl.text,
                   ))
               : null,
-          child: const Text('Finalizar'),
+          icon: const Icon(Icons.check_circle_outline),
+          label: const Text('Finalizar'),
         ),
       ],
     );

--- a/lib/src/features/routines/presentation/widgets/mini_line_chart.dart
+++ b/lib/src/features/routines/presentation/widgets/mini_line_chart.dart
@@ -36,22 +36,36 @@ class MiniLineChart extends StatelessWidget {
           if (last.isNotEmpty)
             LineChartBarData(
               spots: _spots(last),
-              isCurved: false,
+              isCurved: true,
+              barWidth: 2,
               dotData: const FlDotData(show: false),
-              color: Colors.grey,
+              color: Colors.grey.shade600,
             ),
           if (best.isNotEmpty)
             LineChartBarData(
               spots: _spots(best),
-              isCurved: false,
+              isCurved: true,
+              barWidth: 2,
               dotData: const FlDotData(show: false),
-              color: Colors.amber,
+              color: Colors.amber.shade400,
             ),
           LineChartBarData(
             spots: _spots(today),
-            isCurved: false,
+            isCurved: true,
+            barWidth: 3,
             dotData: const FlDotData(show: true),
-            color: Colors.blueAccent,
+            color: Colors.blueAccent.shade200,
+            belowBarData: BarAreaData(
+              show: true,
+              gradient: LinearGradient(
+                colors: [
+                  Colors.blueAccent.shade200.withOpacity(0.3),
+                  Colors.transparent,
+                ],
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+              ),
+            ),
           ),
         ],
       ),

--- a/lib/src/features/routines/presentation/widgets/progress_header.dart
+++ b/lib/src/features/routines/presentation/widgets/progress_header.dart
@@ -8,6 +8,7 @@ class ProgressHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final progress = total == 0 ? 0.0 : completed / total;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 22),
       decoration: BoxDecoration(
@@ -24,16 +25,25 @@ class ProgressHeader extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Ejercicios $completed / $total',
-            style: const TextStyle(fontSize: 16, color: Colors.white),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 250),
+            child: Text(
+              'Ejercicios $completed / $total',
+              key: ValueKey<String>('progress-$completed-$total'),
+              style: const TextStyle(fontSize: 16, color: Colors.white),
+            ),
           ),
           const SizedBox(height: 8),
-          LinearProgressIndicator(
-            value: total == 0 ? 0 : completed / total,
-            minHeight: 6,
-            backgroundColor: Colors.grey.shade700,
-            color: Colors.blueGrey.shade200,
+          TweenAnimationBuilder<double>(
+            duration: const Duration(milliseconds: 450),
+            curve: Curves.easeOutCubic,
+            tween: Tween<double>(begin: 0, end: progress),
+            builder: (_, value, __) => LinearProgressIndicator(
+              value: value,
+              minHeight: 6,
+              backgroundColor: Colors.grey.shade700,
+              color: Colors.blueGrey.shade200,
+            ),
           ),
         ],
       ),

--- a/lib/src/features/routines/presentation/widgets/session_exercise_tile.dart
+++ b/lib/src/features/routines/presentation/widgets/session_exercise_tile.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../widgets/exercise_tile.dart';
+import '../../domain/entities/plan_exercise_detail.dart';
+import '../../domain/entities/workout_log_entry.dart';
+import '../../services/workout_session_helper.dart';
+import '../../../history/presentation/providers/history_providers.dart';
+
+class SessionExerciseTile extends ConsumerWidget {
+  final PlanExerciseDetail detail;
+  final int index;
+  final int? expandedExerciseId;
+  final void Function(int exerciseId) onToggle;
+  final Map<int, GlobalKey<ExerciseTileState>> keys;
+  final Map<String, WorkoutLogEntry> logsMap;
+  final bool highlightDone;
+  final VoidCallback onChanged;
+  final void Function(WorkoutLogEntry) removeLog;
+  final void Function(WorkoutLogEntry) updateLog;
+  final int planId;
+  final bool showBest;
+  final VoidCallback? onSwap;
+
+  const SessionExerciseTile({
+    super.key,
+    required this.detail,
+    required this.index,
+    required this.expandedExerciseId,
+    required this.onToggle,
+    required this.keys,
+    required this.logsMap,
+    required this.highlightDone,
+    required this.onChanged,
+    required this.removeLog,
+    required this.updateLog,
+    required this.planId,
+    required this.showBest,
+    this.onSwap,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    keys[detail.exerciseId] ??= GlobalKey<ExerciseTileState>();
+    final asyncLogs = ref.watch(logsByExerciseProvider(detail.exerciseId));
+    return asyncLogs.when(
+      data: (logs) {
+        final last = WorkoutSessionHelper.lastLogs(logs);
+        final best = WorkoutSessionHelper.bestLogs(logs);
+        return ExerciseTile(
+          key: keys[detail.exerciseId],
+          detail: detail,
+          expanded: expandedExerciseId == detail.exerciseId,
+          onToggle: () => onToggle(detail.exerciseId),
+          logsMap: logsMap,
+          highlightDone: highlightDone,
+          onChanged: onChanged,
+          removeLog: removeLog,
+          update: updateLog,
+          planId: planId,
+          lastLogs: last,
+          bestLogs: best,
+          showBest: showBest,
+          onSwap: onSwap,
+        );
+      },
+      loading: () => ExerciseTile(
+        key: keys[detail.exerciseId],
+        detail: detail,
+        expanded: expandedExerciseId == detail.exerciseId,
+        onToggle: () => onToggle(detail.exerciseId),
+        logsMap: logsMap,
+        highlightDone: highlightDone,
+        onChanged: onChanged,
+        removeLog: removeLog,
+        update: updateLog,
+        planId: planId,
+        showBest: showBest,
+        onSwap: onSwap,
+      ),
+      error: (e, _) => ExerciseTile(
+        key: keys[detail.exerciseId],
+        detail: detail,
+        expanded: expandedExerciseId == detail.exerciseId,
+        onToggle: () => onToggle(detail.exerciseId),
+        logsMap: logsMap,
+        highlightDone: highlightDone,
+        onChanged: onChanged,
+        removeLog: removeLog,
+        update: updateLog,
+        planId: planId,
+        showBest: showBest,
+        onSwap: onSwap,
+      ),
+    );
+  }
+}

--- a/lib/src/features/routines/presentation/widgets/session_summary_card.dart
+++ b/lib/src/features/routines/presentation/widgets/session_summary_card.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+class SessionSummaryCard extends StatelessWidget {
+  final String duration;
+  final String completion;
+  final bool showBest;
+  final VoidCallback onToggleBest;
+
+  const SessionSummaryCard({
+    super.key,
+    required this.duration,
+    required this.completion,
+    required this.showBest,
+    required this.onToggleBest,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1B1B1B),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: const Color(0xFF2A2A2A)),
+      ),
+      child: Row(
+        children: [
+          _buildMetric(
+            icon: Icons.timer_outlined,
+            label: 'Tiempo',
+            value: duration,
+          ),
+          const SizedBox(width: 12),
+          _buildMetric(
+            icon: Icons.check_circle_outline,
+            label: 'Completado',
+            value: completion,
+          ),
+          const Spacer(),
+          IconButton(
+            onPressed: onToggleBest,
+            icon: Icon(
+              showBest ? Icons.star : Icons.star_border,
+              color: colorScheme.primary,
+            ),
+            tooltip: showBest ? 'Ocultar mejores' : 'Ver mejores',
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMetric({
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(icon, size: 16, color: const Color(0xFF8E8CF8)),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: const TextStyle(fontSize: 12, color: Colors.white70),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        Text(
+          value,
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/navigation/main_scaffold.dart
+++ b/lib/src/navigation/main_scaffold.dart
@@ -26,17 +26,30 @@ class _MainScaffoldState extends State<MainScaffold> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: IndexedStack(index: _currentIndex, children: _tabs),
-      bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _currentIndex,
-        onTap: (i) => setState(() => _currentIndex = i),
-        type: BottomNavigationBarType.fixed,
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Inicio'),
-          BottomNavigationBarItem(icon: Icon(Icons.fitness_center), label: 'Rutinas'),
-          // BottomNavigationBarItem(icon: Icon(Icons.history), label: 'Logs'),
-          // BottomNavigationBarItem(icon: Icon(Icons.bar_chart), label: 'Stats'),
-          // BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Perfil'),
-        ],
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(22),
+            child: NavigationBar(
+              selectedIndex: _currentIndex,
+              onDestinationSelected: (i) => setState(() => _currentIndex = i),
+              destinations: const [
+                NavigationDestination(
+                  icon: Icon(Icons.home_outlined),
+                  selectedIcon: Icon(Icons.home),
+                  label: 'Inicio',
+                ),
+                NavigationDestination(
+                  icon: Icon(Icons.fitness_center_outlined),
+                  selectedIcon: Icon(Icons.fitness_center),
+                  label: 'Rutinas',
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -47,22 +60,54 @@ class _HomeTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          const Text('Bienvenido a Fit Log'),
-          const SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => const DataScreen()),
-              );
-            },
-            child: const Text('Data'),
-          ),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.auto_awesome, size: 48, color: Color(0xFF8E8CF8)),
+            const SizedBox(height: 16),
+            const Text(
+              'Bienvenido a Fit Log',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Diseño minimalista, métricas claras y control total de tu progreso.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: colorScheme.onSurface.withOpacity(0.7),
+                fontSize: 14,
+              ),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (_) => const DataScreen()),
+                  );
+                },
+                icon: const Icon(Icons.cloud_download_outlined),
+                label: const Text('Datos y respaldo'),
+                style: ElevatedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
### Motivation
- Provide a cohesive, professional dark UI with a primarily dark-gray tone and refined accents to match a minimal luxurious aesthetic.
- Improve navigation affordances and home screen clarity with a stronger hero section and a primary call-to-action.
- Make routine items feel premium and well-separated by adding rounded cards, accent avatars and clearer iconography.

### Description
- Introduce a custom `ColorScheme` and set `themeMode: ThemeMode.dark`, applying it in `lib/src/app.dart` and replacing the previous light/dark seed setup.
- Add targeted theme customizations including `AppBarTheme`, `CardTheme`, `ListTileThemeData`, `NavigationBarThemeData` (using `MaterialStateProperty`), `FloatingActionButtonThemeData`, `InputDecorationTheme`, and `DividerThemeData` in `lib/src/app.dart`.
- Replace the `BottomNavigationBar` with a rounded `NavigationBar` wrapped in `SafeArea`/`ClipRRect` in `lib/src/navigation/main_scaffold.dart` to achieve the new rounded, separated navigation look.
- Modernize the home module and routines list by updating the home hero and CTA in `main_scaffold.dart` and converting routine rows to `Card` + `ListTile` with `CircleAvatar` initials and refined icons in `lib/src/features/routines/presentation/pages/routines_screen.dart`.

### Testing
- No automated Flutter tests were executed because the Flutter SDK is not available in this environment (checked via `flutter --version`).
- No other automated test runs were requested or performed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69631d81174083239b833c34c5491f93)