### PR TITLE
Improve session feedback snackbars

### DIFF
--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -84,6 +84,8 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     final logsMap = ref.watch(workoutLogProvider);
     final notifier = ref.read(workoutLogProvider.notifier);
     final cs = Theme.of(context).colorScheme;
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    final isKeyboardVisible = bottomInset > 0;
 
     return WillPopScope(
       onWillPop: () async {
@@ -159,20 +161,23 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
             ),
           ],
         ),
-        floatingActionButton: FloatingActionButton.extended(
-          backgroundColor: cs.primary,
-          foregroundColor: cs.onPrimary,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-          icon: const Icon(Icons.check),
-          label: const Text('Registrar serie'),
-          onPressed: () {
-            if (_expandedExerciseId == null) return;
-            _keys[_expandedExerciseId]!
-                .currentState!
-                .logCurrentSet(addOrUpdate: notifier.addOrUpdate);
-            setState(() {});
-          },
-        ),
+        floatingActionButton: isKeyboardVisible
+            ? null
+            : FloatingActionButton.extended(
+                backgroundColor: cs.primary,
+                foregroundColor: cs.onPrimary,
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14)),
+                icon: const Icon(Icons.check),
+                label: const Text('Registrar serie'),
+                onPressed: () {
+                  if (_expandedExerciseId == null) return;
+                  _keys[_expandedExerciseId]!
+                      .currentState!
+                      .logCurrentSet(addOrUpdate: notifier.addOrUpdate);
+                  setState(() {});
+                },
+              ),
         body: asyncAll.when(
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (e, _) => Center(child: Text('$e')),
@@ -206,7 +211,12 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                     ),
                     Expanded(
                       child: ListView.builder(
-                        padding: const EdgeInsets.fromLTRB(12, 16, 12, 80),
+                        padding: EdgeInsets.fromLTRB(
+                          12,
+                          16,
+                          12,
+                          80 + bottomInset,
+                        ),
                         itemCount: entries.length,
                         itemBuilder: (context, index) {
                           final entry = entries[index];

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -43,6 +43,16 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
 
   static const int _defaultSets = 3;
 
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      ),
+    );
+  }
+
   @override
   void initState() {
     super.initState();
@@ -54,9 +64,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
     });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Sesión iniciada')),
-        );
+        _showSnackBar('Sesión en marcha. ¡A por todas!');
       }
     });
   }
@@ -83,9 +91,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
         if (exit) {
           notifier.clear();
           if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Sesión cancelada')),
-            );
+            _showSnackBar('Sesión cancelada. Tu progreso quedó sin guardar.');
           }
         }
         return exit;
@@ -102,9 +108,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
               if (exit) {
                 notifier.clear();
                 if (mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Sesión cancelada')),
-                  );
+                  _showSnackBar('Sesión cancelada. Tu progreso quedó sin guardar.');
                 }
                 if (mounted) Navigator.pop(context);
               }
@@ -121,9 +125,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
               icon: const Icon(Icons.flag),
               onPressed: () async {
                 if (notifier.completedLogs.isEmpty) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('No has completado ninguna serie'))
-                  );
+                  _showSnackBar('Completa al menos una serie antes de finalizar.');
                   return;
                 }
                 final result = await FinishSessionDialog.show(
@@ -150,9 +152,7 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
                 _notesCtl.text = result.notes;
                 notifier.clear();
                 if (mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Sesión finalizada')),
-                  );
+                  _showSnackBar('Sesión finalizada. ¡Gran trabajo hoy!');
                 }
                 if (mounted) Navigator.pop(context);
               },

--- a/lib/src/features/routines/presentation/pages/start_routine_screen.dart
+++ b/lib/src/features/routines/presentation/pages/start_routine_screen.dart
@@ -161,23 +161,26 @@ class _StartRoutineScreenState extends ConsumerState<StartRoutineScreen> {
             ),
           ],
         ),
-        floatingActionButton: isKeyboardVisible
-            ? null
-            : FloatingActionButton.extended(
-                backgroundColor: cs.primary,
-                foregroundColor: cs.onPrimary,
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(14)),
-                icon: const Icon(Icons.check),
-                label: const Text('Registrar serie'),
-                onPressed: () {
-                  if (_expandedExerciseId == null) return;
-                  _keys[_expandedExerciseId]!
-                      .currentState!
-                      .logCurrentSet(addOrUpdate: notifier.addOrUpdate);
-                  setState(() {});
-                },
-              ),
+        floatingActionButton: AnimatedPadding(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+          padding: EdgeInsets.only(bottom: isKeyboardVisible ? bottomInset : 0),
+          child: FloatingActionButton.extended(
+            backgroundColor: cs.primary,
+            foregroundColor: cs.onPrimary,
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            icon: const Icon(Icons.check),
+            label: const Text('Registrar serie'),
+            onPressed: () {
+              if (_expandedExerciseId == null) return;
+              _keys[_expandedExerciseId]!
+                  .currentState!
+                  .logCurrentSet(addOrUpdate: notifier.addOrUpdate);
+              setState(() {});
+            },
+          ),
+        ),
         body: asyncAll.when(
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (e, _) => Center(child: Text('$e')),

--- a/lib/src/features/routines/presentation/widgets/exercise_tile.dart
+++ b/lib/src/features/routines/presentation/widgets/exercise_tile.dart
@@ -58,6 +58,16 @@ class ExerciseTileState extends State<ExerciseTile>
   @override
   bool get wantKeepAlive => true;
 
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      ),
+    );
+  }
+
   double _tonnage(Iterable<WorkoutLogEntry> logs) =>
       logs.fold(0, (s, e) => s + e.reps * e.weight);
 
@@ -144,8 +154,7 @@ class ExerciseTileState extends State<ExerciseTile>
         completed: true,
       ),
     );
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text('Serie $current registrada')));
+    _showSnackBar('Serie $current guardada. Descansa y sigue.');
     setState(widget.onChanged);
     _startRestTimer();
   }


### PR DESCRIPTION
### Motivation
- Improve the clarity and tone of user feedback shown when a workout session starts, is cancelled, finishes, or a set is logged.
- Avoid UI shifting when showing snackbars by using a floating style with margins.
- Centralize snackbar presentation to make message updates consistent across the session screens and tiles.
- Provide friendlier, contextual copy (encouraging and informative) for better UX during a workout.

### Description
- Added a shared floating snackbar helper `void _showSnackBar(String message)` to `StartRoutineScreen` (`lib/src/features/routines/presentation/pages/start_routine_screen.dart`).
- Added the same `_showSnackBar` helper to `ExerciseTileState` (`lib/src/features/routines/presentation/widgets/exercise_tile.dart`) and replaced the inline `ScaffoldMessenger` call used when logging a set.
- Replaced simple messages with more descriptive text: the session start message now uses `"Sesión en marcha. ¡A por todas!"`, cancel message uses `"Sesión cancelada. Tu progreso quedó sin guardar."`, finish message uses `"Sesión finalizada. ¡Gran trabajo hoy!"`, and set logging uses `"Serie $current guardada. Descansa y sigue."`.
- Snackbar style was changed to `SnackBarBehavior.floating` with `margin: const EdgeInsets.fromLTRB(16, 0, 16, 16)` to prevent layout shifts.

### Testing
- No automated tests were run for this change.
- Attempting to run `flutter --version` in the environment failed because the Flutter CLI is not available, so no runtime verification was executed.
- The changes were committed locally and the modified files are `start_routine_screen.dart` and `exercise_tile.dart`.
- Manual / UI validation is recommended when running on a device or emulator to verify snackbar appearance and behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69669bf65ab88323be7f39bdc093f9e5)