### PR TITLE
Include SQLite database in export/import backups

### DIFF
--- a/lib/src/features/app_data/data/repositories/app_data_repository_impl.dart
+++ b/lib/src/features/app_data/data/repositories/app_data_repository_impl.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:sqflite/sqflite.dart';
 import '../../../../data/schema/schemas.dart';
 import '../../domain/repositories/app_data_repository.dart';
 

--- a/lib/src/features/app_data/data/repositories/app_data_repository_impl.dart
+++ b/lib/src/features/app_data/data/repositories/app_data_repository_impl.dart
@@ -11,14 +11,14 @@ class AppDataRepositoryImpl implements AppDataRepository {
   @override
   Future<File> exportData() async {
     final dir = await getApplicationDocumentsDirectory();
+    final databaseDir = await getDatabasesPath();
     final archive = Archive();
     for (final filename in kTableSchemas.keys) {
       final file = File(p.join(dir.path, filename));
-      if (await file.exists()) {
-        final bytes = await file.readAsBytes();
-        archive.addFile(ArchiveFile(filename, bytes.length, bytes));
-      }
+      await _addFileToArchive(archive, file, filename);
     }
+    final databaseFile = File(p.join(databaseDir, 'fit_log.db'));
+    await _addFileToArchive(archive, databaseFile, p.basename(databaseFile.path));
     final encoder = ZipEncoder();
     final data = encoder.encode(archive);
     final outFile = File(p.join(dir.path, 'fitlog_backup.zip'));
@@ -44,6 +44,7 @@ class AppDataRepositoryImpl implements AppDataRepository {
   @override
   Future<void> importData(File file) async {
     final dir = await getApplicationDocumentsDirectory();
+    final databaseDir = await getDatabasesPath();
     final ext = p.extension(file.path).toLowerCase();
     if (ext == '.xlsx') {
       final outFile = File(p.join(dir.path, p.basename(file.path)));
@@ -56,9 +57,15 @@ class AppDataRepositoryImpl implements AppDataRepository {
     for (final archived in archive.files) {
       if (!archived.isFile) continue;
       final name = p.basename(archived.name);
-      final outPath = p.join(dir.path, name);
+      final outPath = name == 'fit_log.db' ? p.join(databaseDir, name) : p.join(dir.path, name);
       final outFile = File(outPath);
       await outFile.writeAsBytes(archived.content as List<int>, flush: true);
     }
+  }
+
+  Future<void> _addFileToArchive(Archive archive, File file, String archiveName) async {
+    if (!await file.exists()) return;
+    final bytes = await file.readAsBytes();
+    archive.addFile(ArchiveFile(archiveName, bytes.length, bytes));
   }
 }


### PR DESCRIPTION
### Motivation
- The export/backup previously only packaged Excel table files while session and log data were migrated to SQLite (`fit_log.db`), causing exports to omit recent data.
- Users expect Export/Share to produce a complete backup that can be restored without data loss. 
- The import path must restore the SQLite DB to the proper databases directory so the app can read migrated sessions/logs after restore.

### Description
- Updated `exportData` in `lib/src/features/app_data/data/repositories/app_data_repository_impl.dart` to call `getDatabasesPath()` and include `fit_log.db` in the zip archive. 
- Added a helper method `_addFileToArchive` to centralize file inclusion logic and replaced ad-hoc file reads with calls to this helper. 
- Updated `importData` to write `fit_log.db` to the databases directory while writing other files to the application documents directory. 
- Preserved the existing external storage copy behavior for the generated `fitlog_backup.zip`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966a1eb1a808323aeedb23dd7dda8b7)